### PR TITLE
PV-safe negative-price charging, backend SOC trajectory, counter fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,8 +208,13 @@ When tomorrow's prices are available, merges today+tomorrow slots, picks cheapes
 ### Per-Slot SOC Validation
 
 After selecting slots, simulates battery forward through every slot. Drops slots that would violate bounds:
-- Charge pushing SOC > capacity → drop most expensive charge
+- Charge pushing SOC > capacity → drop most expensive non-negative charge first, then negative-price charges if needed
 - Discharge pulling SOC < minimum → drop least profitable discharge
+
+Negative-price slots are no longer fully exempt from overflow pruning.
+When PV production combined with grid charging would overfill the battery,
+negative-price charge slots are dropped to prevent forced grid export at
+penalty rates (inverter cannot disconnect PV panels).
 
 ### Arbitrage Price Delta (both mode)
 
@@ -224,7 +229,8 @@ Prevents over-scheduling when PV will fill the battery:
 ```python
 headroom = max(0, max_battery_kwh - current_kwh - net_pv_surplus)
 max_today_slots = floor(headroom / effective_per_slot)
-# Negative-price slots exempt (always profitable)
+# Negative-price slots pass through here (profitable to consume),
+# but _validate_schedule_soc prunes any that would cause overflow.
 ```
 
 ---
@@ -312,12 +318,18 @@ Fetches `energy_state` history from HA API (throttled 60s), shows what actually 
 The coordinator has ~300 lines of scheduling logic that duplicates ems.py. Changes to one must be manually mirrored to the other. This has caused bugs (e.g., missing solar protection in coordinator).
 
 ### 2. Frontend Simulation Divergence
-The JS card has a simplified version of the algorithm. It doesn't do SOC trajectory projection or per-slot validation. Complex scenarios (predictive deficit, SOC validation pruning) won't match the backend.
+The JS card has a simplified version of the algorithm. It doesn't do SOC
+trajectory projection or per-slot validation. Complex scenarios (predictive
+deficit, SOC validation pruning) won't match the backend.
 
 Settings now mirrored in the card's simulation: `reserve_target_pct`,
-`arbitrage_price_delta`. Still missing: per-slot SOC trajectory, validation
-pruning, PV confidence sliding window. When those matter, the backend-
-provided `slot_schedule` attribute is authoritative — the card overlays its
+`arbitrage_price_delta`, PV-aware headroom for negative-price slots.
+Backend-computed SOC trajectory (`backend_soc_trajectory` in `sim_params`)
+is now used for the today-view line chart when no slider overrides are
+active. The card falls back to client-side trajectory only during live
+slider preview. Still missing in client-side sim: validation pruning, PV
+confidence sliding window. The backend-provided `slot_schedule` attribute
+is authoritative — the card overlays its
 own simulation only for live slider previews.
 
 ### 3. PV Confidence Can Over-React
@@ -382,13 +394,31 @@ update warning.
 
 ### Correctness Improvements (Medium Priority)
 
-#### D. SOC Trajectory in Frontend
-**Problem**: The JS card doesn't run the predictive trajectory, so its preview can show different results than the backend.
-**Fix**: Either pass the backend's calculated schedule to the card (already partially done via slot_schedule), or add the trajectory projection to the JS. The simpler approach: always use the backend schedule for display, only simulate for slider preview.
-**Status**: `reserve_target_pct` and `arbitrage_price_delta` are now
-mirrored in both `_simulateSchedule` and `_simulateScheduleTomorrow`
-(via `sim_params`). Trajectory projection and validation pruning still
-live only on the backend.
+#### D. SOC Trajectory in Frontend — IMPLEMENTED
+Backend now computes `soc_trajectory` (list of SOC% per slot) in
+`ScheduleResult` via `_compute_scheduled_soc_trajectory()`. Passed to
+frontend via `sim_params.backend_soc_trajectory`. The card uses this
+authoritative trajectory for the today-view line chart when no overrides
+are active, falling back to client-side simulation only during live slider
+preview. `reserve_target_pct` and `arbitrage_price_delta` are also mirrored
+in both `_simulateSchedule` and `_simulateScheduleTomorrow`.
+
+#### D2. Negative-Price PV Headroom Protection — IMPLEMENTED
+`_validate_schedule_soc` no longer fully exempts negative-price charge
+slots from overflow pruning. When PV production combined with grid charging
+would push SOC above capacity, negative-price slots are dropped (least
+negative first, after non-negative slots). This prevents the inverter
+from being forced to export PV surplus to grid at penalty rates because
+it cannot disconnect PV panels. The headroom cap in
+`select_unified_charge_slots` still allows all negative-price slots through;
+the downstream SOC validation handles the pruning.
+
+#### D3. Available Slots Counter Clarification — IMPLEMENTED
+`available_slots_at_threshold` now counts only today's remaining slots
+(not tomorrow's). Tomorrow's slots are still included in the energy
+capacity calculation for charge likelihood. In `both` mode,
+`cheap_slots_remaining` now counts only charge slots (not charge +
+discharge combined).
 
 #### E. Arbitrage in Both Mode — Charge Slot Selection
 **Problem**: When arbitrage_price_delta triggers full charging, the algorithm uses the same "cheapest slots" logic. But for arbitrage, you specifically want cheap-buy + expensive-sell pairs.
@@ -427,7 +457,7 @@ live only on the backend.
 
 ## Testing
 
-Tests are in `tests/test_ems.py` (99 tests). They import `ems.py` directly (bypassing HA dependencies) and test the pure scheduling functions.
+Tests are in `tests/test_ems.py` (111 tests). They import `ems.py` directly (bypassing HA dependencies) and test the pure scheduling functions.
 
 ```bash
 # Run all tests

--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -112,9 +112,11 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self.tomorrow_precharge: float = 0.0
         self.tomorrow_planned_slots: int = 0
         self.tomorrow_planned_kwh: float = 0.0
+        self._backend_soc_trajectory: list[float] = []
 
         # Always-visible slot info (regardless of price_mode)
         self.available_slots_at_threshold: int = 0
+        self._available_total_with_tomorrow: int = 0
         self.available_energy_capacity: float = 0.0
         self.charge_likelihood: str = "unknown"
 
@@ -637,6 +639,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self.tomorrow_planned_slots = result.tomorrow_planned_slots
         self.tomorrow_planned_kwh = result.tomorrow_planned_kwh
         self.schedule_status = result.status
+        self._backend_soc_trajectory = result.soc_trajectory
 
         if result.price_threshold is not None:
             self.price_threshold = result.price_threshold
@@ -734,8 +737,9 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
                 elif effective_mode != "from_grid" and tp >= self.price_threshold:
                     tomorrow_available += 1
 
-        self.available_slots_at_threshold = len(available) + tomorrow_available
-        self.available_energy_capacity = round(self.available_slots_at_threshold * energy_per_slot, 2)
+        self.available_slots_at_threshold = len(available)
+        self._available_total_with_tomorrow = len(available) + tomorrow_available
+        self.available_energy_capacity = round(self._available_total_with_tomorrow * energy_per_slot, 2)
 
         # Set schedule_status for manual mode (schedule optimizer only runs in auto)
         if price_mode == "manual":
@@ -792,7 +796,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
                 self.charge_likelihood = "idle (sell mode info)"
             elif sellable <= 0:
                 self.charge_likelihood = "nothing_to_sell"
-            elif self.available_slots_at_threshold > 0:
+            elif self._available_total_with_tomorrow > 0:
                 self.charge_likelihood = "selling"
             else:
                 self.charge_likelihood = "no_profitable_slots"

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -60,6 +60,7 @@ class ScheduleResult:
     tomorrow_planned_kwh: float = 0.0
     tomorrow_precharge: float = 0.0
     status: str = "off"
+    soc_trajectory: list[float] = field(default_factory=list)
 
 
 @dataclass
@@ -332,6 +333,61 @@ def _project_soc_trajectory(
     return projection, min_soc, max_soc
 
 
+def _compute_scheduled_soc_trajectory(
+    prices: list[float | None],
+    num_slots: int,
+    minutes_per_slot: float,
+    current_kwh: float,
+    current_slot: int,
+    scheduled_slots: dict[int, str],
+    config: EMSConfig,
+    state: EMSState,
+) -> list[float]:
+    """Compute SOC% trajectory for all slots using the finalized schedule.
+
+    Returns a list of SOC% values (one per slot, from slot 0 to num_slots-1).
+    Past slots (before current_slot) use current_kwh back-projected;
+    future slots simulate forward with PV, consumption, and scheduled actions.
+    """
+    pv_confidence = _calculate_pv_confidence(
+        state.pv_hourly_kwh, state.pv_actual_today_kwh,
+        state.current_hour, state.current_minute,
+    )
+    energy_per_slot = config.safe_power_kw * (minutes_per_slot / 60.0)
+    min_kwh = (config.battery_discharge_min_pct / 100.0) * config.battery_capacity_kwh
+    cap = config.battery_capacity_kwh
+
+    trajectory: list[float] = []
+    soc = current_kwh
+
+    for i in range(num_slots):
+        if i == current_slot:
+            soc = current_kwh
+
+        pct = max(0.0, min(100.0, (soc / cap) * 100.0)) if cap > 0 else 0.0
+        trajectory.append(round(pct, 1))
+
+        hour = int((i * minutes_per_slot) / 60)
+        pv_kwh = (state.pv_hourly_kwh or {}).get(hour, 0.0) * pv_confidence
+        pv_per_slot = pv_kwh * (minutes_per_slot / 60.0)
+
+        if state.consumption_hourly_kwh and hour in state.consumption_hourly_kwh:
+            cons = state.consumption_hourly_kwh[hour] * (minutes_per_slot / 60.0)
+        else:
+            cons = (config.consumption_est_kwh / num_slots)
+
+        delta = pv_per_slot - cons
+        action = scheduled_slots.get(i)
+        if action == "charge":
+            delta += energy_per_slot * config.efficiency
+        elif action == "discharge" and soc > min_kwh:
+            delta -= min(energy_per_slot, soc - min_kwh)
+
+        soc = max(min_kwh, min(cap, soc + delta))
+
+    return trajectory
+
+
 def _validate_schedule_soc(
     remaining: list[tuple[int, float]],
     charge_slots: set[int],
@@ -423,8 +479,11 @@ def _validate_schedule_soc(
                 drop, price_of.get(drop, 0.0), violation_slot,
             )
         else:
-            # Remove the most expensive non-negative charge at or before violation.
-            # Negative-price slots are always profitable — exempt from overflow.
+            # Remove the most expensive charge at or before violation.
+            # Prefer dropping non-negative slots first; fall back to
+            # negative-price slots if those are the only ones left —
+            # a negative-price slot that overflows the battery still
+            # causes forced PV export at penalty rates.
             candidates = [
                 s for s in charge_slots
                 if s <= violation_slot and price_of.get(s, 0.0) >= 0
@@ -435,7 +494,13 @@ def _validate_schedule_soc(
                     if price_of.get(s, 0.0) >= 0
                 ]
             if not candidates:
-                # Only negative-price charge slots remain — keep them all
+                candidates = [
+                    s for s in charge_slots
+                    if s <= violation_slot
+                ]
+            if not candidates:
+                candidates = list(charge_slots)
+            if not candidates:
                 break
             # Remove the most expensive charge slot
             drop = max(candidates, key=lambda s: price_of.get(s, 0.0))
@@ -543,11 +608,10 @@ def select_unified_charge_slots(
     headroom = max(0.0, max_battery_kwh - current_kwh - pv_fill)
     max_today_slots = math.floor(headroom / effective_per_slot) if effective_per_slot > 0 else 0
     today_deficit_slots = math.ceil(energy_deficit / effective_per_slot) if effective_per_slot > 0 and energy_deficit > 0 else 0
-    # Negative-price slots are always profitable — exempt from headroom cap
     neg_today_count = sum(1 for s in today_selected if s[0] < 0)
-    # Only let deficit override headroom when there's no PV surplus filling
-    # the battery.  When PV will fill the battery, headroom is the real
-    # physical limit and deficit slots would just overcharge.
+    # Allow negative-price slots through: they're profitable (paid to consume).
+    # SOC validation downstream will prune any that would cause battery overflow
+    # when combined with PV production.
     if pv_fill <= 0:
         max_today_slots = max(max_today_slots, today_deficit_slots, neg_today_count)
     else:
@@ -715,6 +779,14 @@ def calculate_schedule(config: EMSConfig, state: EMSState) -> ScheduleResult:
         result.status = "active"
     else:
         result.status = "waiting"
+
+    # Compute authoritative SOC trajectory with the finalized schedule
+    result.soc_trajectory = _compute_scheduled_soc_trajectory(
+        prices, num_slots, minutes_per_slot,
+        current_kwh, current_slot,
+        result.scheduled_slots,
+        config, state,
+    )
 
     return result
 
@@ -1055,7 +1127,7 @@ def _schedule_both(
     for s in sell_selected:
         result.scheduled_slots[s[0]] = "discharge"
 
-    result.cheap_slots_remaining = len(result.scheduled_slots)
+    result.cheap_slots_remaining = len(charge_slots)
     charge_energy = round(len(charge_slots) * effective_per_slot, 2) if charge_slots else 0
     sell_energy = round(min(sellable, len(sell_selected) * energy_per_slot), 2) if sellable > 0 else 0
     result.grid_energy_planned = round(charge_energy + sell_energy, 2)
@@ -1109,8 +1181,9 @@ def calculate_available_info(
             elif effective_mode != "from_grid" and tp >= price_threshold:
                 tomorrow_available += 1
 
-    info.available_slots = len(available) + tomorrow_available
-    info.available_energy_capacity = round(info.available_slots * energy_per_slot, 2)
+    info.available_slots = len(available)
+    total_with_tomorrow = len(available) + tomorrow_available
+    info.available_energy_capacity = round(total_with_tomorrow * energy_per_slot, 2)
 
     if state.battery_soc_pct is None:
         info.charge_likelihood = "unknown"
@@ -1158,7 +1231,7 @@ def calculate_available_info(
             info.charge_likelihood = "idle (sell mode info)"
         elif sellable <= 0:
             info.charge_likelihood = "nothing_to_sell"
-        elif info.available_slots > 0:
+        elif total_with_tomorrow > 0:
             info.charge_likelihood = "selling"
         else:
             info.charge_likelihood = "no_profitable_slots"

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -327,11 +327,18 @@ class FelicityEMSCard extends LitElement {
         let tomorrowCharge = allSelected.filter(s => s.day === 1);
 
         // Battery headroom cap: today can only charge what the battery can absorb
-        const headroom = Math.max(0, chargeMax * batteryCapacity - currentKwh);
-        const maxTodaySlots = Math.max(
-          effectivePerSlot > 0 ? Math.floor(headroom / effectivePerSlot) : 0,
-          effectivePerSlot > 0 && deficit > 0 ? Math.ceil(deficit / effectivePerSlot) : 0
-        );
+        const pvFill = Math.max(0, netPv);
+        const headroom = Math.max(0, chargeMax * batteryCapacity - currentKwh - pvFill);
+        let maxTodaySlots = effectivePerSlot > 0 ? Math.floor(headroom / effectivePerSlot) : 0;
+        const negTodayCount = todayCharge.filter(s => s.price < 0).length;
+        if (pvFill <= 0) {
+          maxTodaySlots = Math.max(maxTodaySlots,
+            effectivePerSlot > 0 && deficit > 0 ? Math.ceil(deficit / effectivePerSlot) : 0,
+            negTodayCount
+          );
+        } else {
+          maxTodaySlots = Math.max(maxTodaySlots, negTodayCount);
+        }
         if (todayCharge.length > maxTodaySlots) {
           todayCharge.sort((a, b) => a.price - b.price);  // cheapest first
           const excess = todayCharge.slice(maxTodaySlots);
@@ -712,7 +719,14 @@ class FelicityEMSCard extends LitElement {
     }
 
     // ── SOC trajectory (solid past / dotted future) ──────────────────
-    const socTrajectory = this._computeSocTrajectory(displayData, showTomorrow);
+    // Prefer backend-computed trajectory when no overrides are active
+    const hasOverrides = this._simOverrides && Object.keys(this._simOverrides).length > 0;
+    const backendTrajectory = (!hasOverrides && !showTomorrow)
+      ? ((this._getAttr("schedule_status", "sim_params") || {}).backend_soc_trajectory || null)
+      : null;
+    const socTrajectory = (backendTrajectory && backendTrajectory.length === numSlots)
+      ? backendTrajectory
+      : this._computeSocTrajectory(displayData, showTomorrow);
     const socHistory = this._getAttr("schedule_status", "soc_history") || {};
 
     if (socTrajectory && socTrajectory.length > 1) {

--- a/custom_components/ha_felicity/sensor.py
+++ b/custom_components/ha_felicity/sensor.py
@@ -185,6 +185,7 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
                 "pv_hourly_kwh": self.coordinator.pv_hourly_kwh or {},
                 "pv_confidence": getattr(self.coordinator, '_last_pv_confidence', 1.0),
                 "consumption_hourly_profile": self.coordinator._hourly_consumption_profile or {},
+                "backend_soc_trajectory": self.coordinator._backend_soc_trajectory,
             },
             "soc_history": self.coordinator._soc_history,
             "slot_overrides": self.coordinator.slot_overrides if self.coordinator.slot_overrides else {},

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -742,7 +742,24 @@ class TestCalculateSchedule:
         assert len(discharge_slots) == 0
 
     def test_negative_prices_from_grid(self):
-        """Negative prices always trigger charging in from_grid mode."""
+        """Negative prices trigger charging when battery has room."""
+        config = default_config(battery_capacity_kwh=60.0)
+        prices = make_prices(24, pattern="negative")
+        state = default_state(
+            battery_soc_pct=40.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(10.0),
+            pv_forecast_remaining=5.0,
+            pv_actual_today_kwh=5.0,
+            current_hour=0,
+        )
+        result = calculate_schedule(config, state)
+        charge_slots = [k for k, v in result.scheduled_slots.items() if v == "charge"]
+        charged_neg = sum(1 for s in charge_slots if prices[s] < 0)
+        assert charged_neg > 0
+
+    def test_negative_prices_skipped_when_pv_fills_battery(self):
+        """Negative-price charging skipped when PV would overfill the battery."""
         config = default_config()
         prices = make_prices(24, pattern="negative")
         state = default_state(
@@ -755,9 +772,7 @@ class TestCalculateSchedule:
         )
         result = calculate_schedule(config, state)
         charge_slots = [k for k, v in result.scheduled_slots.items() if v == "charge"]
-        # Should charge during negative price slots even with full-ish battery
-        charged_neg = sum(1 for s in charge_slots if prices[s] < 0)
-        assert charged_neg > 0
+        assert len(charge_slots) == 0
 
     def test_yesterday_deficit_carryover(self):
         """Yesterday's deficit increases today's charging."""
@@ -1045,9 +1060,25 @@ class TestScenarios:
         assert result.tomorrow_planned_kwh > 0
 
     def test_scenario_negative_prices_bonus_charge(self):
-        """When negative prices appear, always charge even if battery is fine."""
+        """Negative prices trigger charging when battery has room."""
+        config = default_config(battery_capacity_kwh=60.0, consumption_est_kwh=20.0)
+        prices = [0.25] * 10 + [-0.05, -0.03, -0.01] + [0.25] * 11
+        state = default_state(
+            battery_soc_pct=40.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(10.0),
+            pv_forecast_remaining=5.0,
+            pv_actual_today_kwh=5.0,
+            current_hour=0,
+        )
+        result = calculate_schedule(config, state)
+        charge_slots = [k for k, v in result.scheduled_slots.items() if v == "charge"]
+        neg_slots = [s for s in charge_slots if prices[s] < 0]
+        assert len(neg_slots) >= 1
+
+    def test_scenario_negative_prices_skipped_when_battery_full_with_pv(self):
+        """Negative prices skipped when PV + high SOC leaves no room."""
         config = default_config(consumption_est_kwh=20.0)
-        # Some negative slots mixed in
         prices = [0.25] * 10 + [-0.05, -0.03, -0.01] + [0.25] * 11
         state = default_state(
             battery_soc_pct=70.0,
@@ -1059,9 +1090,49 @@ class TestScenarios:
         )
         result = calculate_schedule(config, state)
         charge_slots = [k for k, v in result.scheduled_slots.items() if v == "charge"]
-        # Negative price slots should be included
         neg_slots = [s for s in charge_slots if prices[s] < 0]
-        assert len(neg_slots) >= 1  # at least some negative slots selected
+        # With 10 kWh battery at 70% and 35 kWh PV, no room for grid charging
+        assert len(neg_slots) == 0
+
+    def test_scenario_both_mode_negative_prices_with_headroom(self):
+        """Both mode charges at negative prices when battery has room."""
+        config = default_config(
+            grid_mode="both", battery_capacity_kwh=60.0,
+            consumption_est_kwh=20.0, arbitrage_price_delta=0.20,
+        )
+        prices = [0.05] * 4 + [-0.10, -0.08, -0.05] + [0.30] * 17
+        state = default_state(
+            battery_soc_pct=30.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(15.0),
+            pv_forecast_remaining=10.0,
+            pv_actual_today_kwh=5.0,
+            current_hour=0,
+        )
+        result = calculate_schedule(config, state)
+        charge_slots = [k for k, v in result.scheduled_slots.items() if v == "charge"]
+        neg_slots = [s for s in charge_slots if prices[s] < 0]
+        assert len(neg_slots) >= 1
+
+    def test_scenario_both_mode_negative_prices_limited_by_pv(self):
+        """Both mode limits negative-price charging when PV would overflow battery."""
+        config = default_config(
+            grid_mode="both", consumption_est_kwh=10.0,
+        )
+        # Lots of negative-price slots during PV hours
+        prices = [0.10] * 6 + [-0.05] * 8 + [0.10] * 10
+        state = default_state(
+            battery_soc_pct=80.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(40.0),
+            pv_forecast_remaining=25.0,
+            pv_actual_today_kwh=15.0,
+            current_hour=0,
+        )
+        result = calculate_schedule(config, state)
+        charge_slots = [k for k, v in result.scheduled_slots.items() if v == "charge"]
+        # Battery at 80% with 40 kWh PV on 10 kWh battery: almost no room
+        assert len(charge_slots) <= 2
 
 
 # ---------------------------------------------------------------------------
@@ -1130,6 +1201,58 @@ class TestPVConfidence:
         conf_14 = _calculate_pv_confidence(pv, expected_by_14 * 0.5, 14)
         # Hour 9 should be closer to 1.0 than hour 14
         assert conf_9 > conf_14, f"Early confidence {conf_9} should be higher than midday {conf_14}"
+
+
+class TestBackendSocTrajectory:
+    """Tests for the authoritative SOC trajectory returned by calculate_schedule."""
+
+    def test_trajectory_length_matches_slots(self):
+        """Backend trajectory has one entry per slot."""
+        config = default_config()
+        state = default_state(battery_soc_pct=50.0, current_hour=0)
+        result = calculate_schedule(config, state)
+        num_slots = len(state.slot_prices_today)
+        assert len(result.soc_trajectory) == num_slots
+
+    def test_trajectory_reflects_charging(self):
+        """SOC rises at charge slots."""
+        config = default_config(consumption_est_kwh=5.0)
+        prices = [0.05] * 4 + [0.30] * 20
+        state = default_state(
+            battery_soc_pct=30.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh={},
+            pv_forecast_remaining=0.0,
+            current_hour=0,
+        )
+        result = calculate_schedule(config, state)
+        assert len(result.soc_trajectory) == 24
+        charge_slots = [k for k, v in result.scheduled_slots.items() if v == "charge"]
+        if charge_slots:
+            first = min(charge_slots)
+            last = max(charge_slots)
+            # SOC at last+1 (if exists) or last should be higher than at first
+            after_last = min(last + 1, len(result.soc_trajectory) - 1)
+            assert result.soc_trajectory[after_last] > result.soc_trajectory[first]
+
+    def test_trajectory_no_schedule_still_returned(self):
+        """Even with no scheduled actions, trajectory is computed."""
+        config = default_config(grid_mode="from_grid")
+        state = default_state(
+            battery_soc_pct=95.0,
+            pv_hourly_kwh=make_pv_hourly(40.0),
+            pv_forecast_remaining=20.0,
+            current_hour=0,
+        )
+        result = calculate_schedule(config, state)
+        assert len(result.soc_trajectory) == len(state.slot_prices_today)
+
+    def test_trajectory_off_mode_empty(self):
+        """Grid mode off produces empty trajectory."""
+        config = default_config(grid_mode="off")
+        state = default_state(battery_soc_pct=50.0)
+        result = calculate_schedule(config, state)
+        assert result.soc_trajectory == []
 
 
 class TestSOCTrajectory:


### PR DESCRIPTION
Three fixes for user-reported issues:

1. Negative-price slots in both mode now respect battery headroom. _validate_schedule_soc no longer exempts negative-price charge slots from overflow pruning — when PV + grid charging would push SOC above capacity, negative-price slots are dropped (least negative first). Prevents forced PV export at penalty rates since the inverter cannot disconnect PV panels.

2. Backend-computed SOC trajectory (soc_trajectory on ScheduleResult) is now passed to the frontend via sim_params.backend_soc_trajectory. The card uses this authoritative trajectory when no slider overrides are active, ensuring the displayed prediction updates every 10s cycle with fresh PV confidence, actual SOC, and schedule changes.

3. Available Slots counter now shows today-only count (was inflated by including tomorrow's slots). Cheap Slots Remaining in both mode now counts only charge slots (was confusingly including discharge slots).

Tests: 111 passed (was 103), including new coverage for negative-price PV overflow, both-mode headroom, and backend SOC trajectory.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF