### PR TITLE
Only color negative-price slots blue when they are scheduled for char…

### DIFF
--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -346,8 +346,9 @@ def _compute_scheduled_soc_trajectory(
     """Compute SOC% trajectory for all slots using the finalized schedule.
 
     Returns a list of SOC% values (one per slot, from slot 0 to num_slots-1).
-    Past slots (before current_slot) use current_kwh back-projected;
-    future slots simulate forward with PV, consumption, and scheduled actions.
+    Past slots use current_kwh as placeholder (frontend uses soc_history
+    for past slots instead). Future slots simulate forward with PV,
+    consumption, and scheduled actions.
     """
     pv_confidence = _calculate_pv_confidence(
         state.pv_hourly_kwh, state.pv_actual_today_kwh,
@@ -356,11 +357,16 @@ def _compute_scheduled_soc_trajectory(
     energy_per_slot = config.safe_power_kw * (minutes_per_slot / 60.0)
     min_kwh = (config.battery_discharge_min_pct / 100.0) * config.battery_capacity_kwh
     cap = config.battery_capacity_kwh
+    current_pct = max(0.0, min(100.0, (current_kwh / cap) * 100.0)) if cap > 0 else 0.0
 
     trajectory: list[float] = []
     soc = current_kwh
 
     for i in range(num_slots):
+        if i < current_slot:
+            trajectory.append(round(current_pct, 1))
+            continue
+
         if i == current_slot:
             soc = current_kwh
 

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -608,11 +608,9 @@ class FelicityEMSCard extends LitElement {
       if (showTomorrow) {
         // Tomorrow: color by simulated action
         if (slot.action === "charge") {
-          ctx.fillStyle = "rgba(76, 175, 80, 0.6)"; // green, slightly softer
+          ctx.fillStyle = price < 0 ? "rgba(33, 150, 243, 0.6)" : "rgba(76, 175, 80, 0.6)";
         } else if (slot.action === "discharge") {
           ctx.fillStyle = "rgba(255, 152, 0, 0.6)"; // orange, slightly softer
-        } else if (price < 0) {
-          ctx.fillStyle = "rgba(33, 150, 243, 0.6)";
         } else {
           ctx.fillStyle = "rgba(100, 140, 200, 0.35)";
         }
@@ -625,11 +623,9 @@ class FelicityEMSCard extends LitElement {
         } else if (isPast && pastAction === "discharging") {
           ctx.fillStyle = "rgba(255, 152, 0, 0.3)";  // dim orange — actually discharged
         } else if (slot.action === "charge") {
-          ctx.fillStyle = isPast ? "rgba(150, 150, 150, 0.2)" : "#4CAF50";
+          ctx.fillStyle = isPast ? "rgba(150, 150, 150, 0.2)" : (price < 0 ? "#2196F3" : "#4CAF50");
         } else if (slot.action === "discharge") {
           ctx.fillStyle = isPast ? "rgba(150, 150, 150, 0.2)" : "#FF9800";
-        } else if (price < 0) {
-          ctx.fillStyle = isPast ? "rgba(33, 150, 243, 0.3)" : "#2196F3";
         } else {
           ctx.fillStyle = isPast ? "rgba(150, 150, 150, 0.2)" : "rgba(150, 150, 150, 0.4)";
         }

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -715,9 +715,15 @@ class FelicityEMSCard extends LitElement {
     }
 
     // ── SOC trajectory (solid past / dotted future) ──────────────────
-    // Prefer backend-computed trajectory when no overrides are active
-    const hasOverrides = this._simOverrides && Object.keys(this._simOverrides).length > 0;
-    const backendTrajectory = (!hasOverrides && !showTomorrow)
+    // Prefer backend-computed trajectory when no overrides are active.
+    // Fall back to client-side simulation when user is previewing via
+    // sliders (_simOverrides) or manual slot clicks (_slotOverrides).
+    const hasSliderOverrides = this._simOverrides && Object.keys(this._simOverrides).length > 0;
+    const hasSlotOverrides = this._slotOverrides
+      && (Object.keys(this._slotOverrides.today || {}).length > 0
+          || Object.keys(this._slotOverrides.tomorrow || {}).length > 0);
+    const hasAnyOverrides = hasSliderOverrides || hasSlotOverrides;
+    const backendTrajectory = (!hasAnyOverrides && !showTomorrow)
       ? ((this._getAttr("schedule_status", "sim_params") || {}).backend_soc_trajectory || null)
       : null;
     const socTrajectory = (backendTrajectory && backendTrajectory.length === numSlots)


### PR DESCRIPTION
…ging

Blue bars were confusing users — they appeared for ALL negative-price slots regardless of whether the algorithm scheduled them for charging. Now blue only shows for negative-price charge slots (action=charge + price<0). Unscheduled negative-price slots render as regular idle bars.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF