### PR TITLE
Fix duplicate variable declaration causing SyntaxError

### DIFF
--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -768,11 +768,6 @@ class FelicityEMSCard extends LitElement {
     // Prefer backend-computed trajectory when no overrides are active.
     // Fall back to client-side simulation when user is previewing via
     // sliders (_simOverrides) or manual slot clicks (_slotOverrides).
-    const hasSliderOverrides = this._simOverrides && Object.keys(this._simOverrides).length > 0;
-    const hasSlotOverrides = this._slotOverrides
-      && (Object.keys(this._slotOverrides.today || {}).length > 0
-          || Object.keys(this._slotOverrides.tomorrow || {}).length > 0);
-    const hasAnyOverrides = hasSliderOverrides || hasSlotOverrides;
     const backendTrajectory = (!hasAnyOverrides && !showTomorrow)
       ? ((this._getAttr("schedule_status", "sim_params") || {}).backend_soc_trajectory || null)
       : null;


### PR DESCRIPTION
hasSliderOverrides/hasSlotOverrides/hasAnyOverrides were declared twice in _drawSlotTimeline — once for backend schedule selection and again for SOC trajectory. Removed the second set and reuse the existing variables.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF