### PR TITLE
Include charge energy in sellable calculation for both mode

### DIFF
--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -1083,17 +1083,6 @@ def _schedule_both(
                     price_spread, config.arbitrage_price_delta, energy_deficit,
                 )
 
-    # Predictive sellable: use peak projected SOC above reserve.
-    # When arbitrage is active, sellable is based on full capacity since
-    # we're charging to max.
-    # Safety margin (15%): accounts for consumption estimate errors,
-    # PV forecast uncertainty, and the gap between peak SOC (midday)
-    # and actual SOC when discharge slots fire (evening).
-    if arbitrage_active:
-        sellable = max(0.0, max_battery_kwh - reserve_target) * config.efficiency * 0.85
-    else:
-        sellable = max(0.0, max_projected - reserve_target) * config.efficiency * 0.85
-
     charge_slots, tomorrow_slots, tomorrow_charge_kwh = select_unified_charge_slots(
         remaining, energy_deficit, effective_per_slot,
         config.battery_capacity_kwh, config.battery_discharge_min_pct,
@@ -1109,6 +1098,19 @@ def _schedule_both(
     result.tomorrow_precharge = round(-tomorrow_charge_kwh, 2) if tomorrow_charge_kwh > 0 else 0.0
     result.tomorrow_planned_slots = len(tomorrow_slots)
     result.tomorrow_planned_kwh = tomorrow_charge_kwh
+
+    # Sellable energy: peak projected SOC above reserve.
+    # After charge selection, include the planned charge energy so the sell
+    # side knows the battery will have surplus to sell.  Without this, a low
+    # PV-confidence day would show 0 sellable despite grid-charging the
+    # battery well above reserve.  The downstream SOC validation prunes any
+    # sell slots that would actually drain the battery below reserve.
+    if arbitrage_active:
+        sellable = max(0.0, max_battery_kwh - reserve_target) * config.efficiency * 0.85
+    else:
+        charge_energy_planned = len(charge_slots) * effective_per_slot
+        peak_with_charge = min(max_battery_kwh, max_projected + charge_energy_planned)
+        sellable = max(0.0, peak_with_charge - reserve_target) * config.efficiency * 0.85
 
     charge_slot_indices = {s[0] for s in charge_slots}
 

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -403,9 +403,12 @@ class FelicityEMSCard extends LitElement {
       const minKwh = dischargeMin * batteryCapacity;
       const reserveKwh = parseFloat(this._getAttr("schedule_status", "self_consumption_reserve")) || 0;
       const reserveTarget = computeReserveTarget(minKwh, reserveKwh);
-      // Safety margin (15%) matches backend to avoid over-scheduling discharge.
-      // With arbitrage active, we charge to full, so peak SOC is maxBatteryKwh.
-      const peakKwh = arbitrageActive ? maxBatteryKwh : currentKwh;
+      // Include planned charge energy in peak estimate so the sell side
+      // knows the battery will have surplus.  SOC validation prunes any
+      // sells that would actually drain below reserve.
+      const chargeEnergyPlanned = result.chargeCount * effectivePerSlot;
+      const peakWithCharge = Math.min(maxBatteryKwh, currentKwh + chargeEnergyPlanned);
+      const peakKwh = arbitrageActive ? maxBatteryKwh : peakWithCharge;
       const sellable = Math.max(0, peakKwh - reserveTarget) * efficiency * 0.85;
       const roundTrip = efficiency * efficiency;
 
@@ -1031,14 +1034,12 @@ class FelicityEMSCard extends LitElement {
     }
 
     if (gridMode === "to_grid" || gridMode === "both") {
-      // For selling tomorrow: estimate available energy after solar charges the battery
-      // Battery fills from startKwh + pvTomorrow, capped at charge_max.
-      // When arbitrage is active, we'll be grid-charging to full, so the
-      // peak SOC is max capacity — more energy available to sell.
+      // Include planned charge energy + PV in peak estimate so sell side
+      // sees the surplus.  SOC validation prunes overcommitted sells.
+      const chargeEnergyPlanned = result.chargeCount * effectivePerSlot;
       const projectedKwh = arbitrageActive
         ? maxBatteryKwh
-        : Math.min(maxBatteryKwh, startKwh + pvTomorrow);
-      // Safety margin (15%) matches backend to avoid over-scheduling discharge
+        : Math.min(maxBatteryKwh, startKwh + pvTomorrow + chargeEnergyPlanned);
       const sellable = Math.max(0, projectedKwh - reserveTarget) * efficiency * 0.85;
       const roundTrip = efficiency * efficiency;
 

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -2537,3 +2537,61 @@ class TestInverterMaxPowerCap:
             safe_power_kw=0.0,
         )
         assert 12 in validated_charge
+
+
+class TestBothModeSellWithChargeEnergy:
+    """Tests that both mode sells surplus from grid-charged energy."""
+
+    def test_sell_slots_when_pv_confidence_low(self):
+        """Both mode should sell surplus even when PV confidence is near zero.
+
+        Scenario: battery at 28%, PV confidence 0.1 (0 kWh produced),
+        grid charges several slots bringing battery well above reserve.
+        The sell side should see the surplus and schedule discharge.
+        """
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=13.0,
+            safe_power_kw=12.5,
+            inverter_max_power_kw=25.0,
+        )
+        prices = [0.02] * 6 + [0.05] * 6 + [0.08] * 6 + [0.15] * 6
+        state = default_state(
+            battery_soc_pct=28.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(39.0),
+            pv_forecast_remaining=24.0,
+            pv_forecast_today=39.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=10,
+        )
+        result = calculate_schedule(config, state)
+        charge_count = sum(1 for v in result.scheduled_slots.values() if v == "charge")
+        sell_count = sum(1 for v in result.scheduled_slots.values() if v == "discharge")
+        assert charge_count > 0, "Should have charge slots"
+        assert sell_count > 0, "Should have sell slots — charge energy creates surplus above reserve"
+
+    def test_no_sell_when_all_prices_equal(self):
+        """No sell slots when all prices are identical (profitability filter blocks)."""
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=40.0,
+            safe_power_kw=5.0,
+        )
+        prices = [0.10] * 24
+        state = default_state(
+            battery_soc_pct=20.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh={},
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=0.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=0,
+        )
+        result = calculate_schedule(config, state)
+        sell_count = sum(1 for v in result.scheduled_slots.values() if v == "discharge")
+        assert sell_count == 0


### PR DESCRIPTION
In both mode, the sell side calculated sellable energy from the natural PV-only trajectory (max_projected). On low PV-confidence days (e.g. 0 kWh produced → confidence 0.1), max_projected barely reaches reserve_target, so sellable = 0 even though grid charging brings the battery well above reserve.

Fix: after charge slot selection, recalculate sellable including the planned charge energy: peak_with_charge = max_projected + charge_kwh. The profitability filter still ensures sells are only scheduled when the sell price exceeds the round-trip cost of the charge price. SOC validation prunes any sells that would drain below reserve.

Applied to backend (ems.py) and both frontend simulation functions.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF