### PR TITLE
Backend as single source of truth for tomorrow schedule + SOC trajectory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ custom_components/ha_felicity/
     └── ha_felicity_ems.js   # LitElement EMS dashboard card (1671 lines)
 
 tests/
-└── test_ems.py              # 115 tests for the pure EMS algorithm
+└── test_ems.py              # 130 tests for the pure EMS algorithm
 ```
 
 ---
@@ -278,6 +278,14 @@ Also detects external changes (user adjusting via inverter app).
 ### Client-Side Simulation
 Mirrors coordinator logic for instant preview when dragging sliders. Uses `sim_params` from `schedule_status` sensor attributes.
 
+**Backend as single source of truth**: For both today and tomorrow views,
+when no slider or slot overrides are active, the card uses
+backend-provided `slot_schedule` / `slot_schedule_tomorrow` (with actions)
+and `backend_soc_trajectory` / `backend_soc_trajectory_tomorrow` for the
+SOC line. Client-side simulation (`_simulateSchedule`,
+`_simulateScheduleTomorrow`, `_computeSocTrajectory`) only runs when the
+user is actively previewing via sliders or manual slot clicks.
+
 ### Past Slot History
 Fetches `energy_state` history from HA API (throttled 60s), shows what actually happened vs what was planned.
 
@@ -292,7 +300,7 @@ Fetches `energy_state` history from HA API (throttled 60s), shows what actually 
 | grid_mode | select | off/from_grid/to_grid/both | off | Main EMS switch |
 | price_mode | select | manual/auto | manual | Price threshold mode |
 | safe_power_management | select | auto/on/off | auto | Amperage protection |
-| power_level | number | 1-10 kW | 5 | Charge/discharge power |
+| power_level | number | 1-N kW (model max) | 5 | Charge/discharge power |
 | price_threshold_level | number | 1-10 | 5 | Manual price level |
 | battery_charge_max_level | number | 30-100% | 100 | Max SOC for charging |
 | battery_discharge_min_level | number | 10-70% | 20 | Min SOC for discharging |
@@ -465,7 +473,7 @@ discharge combined).
 
 ## Testing
 
-Tests are in `tests/test_ems.py` (115 tests). They import `ems.py` directly (bypassing HA dependencies) and test the pure scheduling functions.
+Tests are in `tests/test_ems.py` (130 tests). They import `ems.py` directly (bypassing HA dependencies) and test the pure scheduling functions.
 
 ```bash
 # Run all tests
@@ -485,6 +493,10 @@ python -m pytest tests/test_ems.py::TestSolarProtection -v
 - Reserve target override
 - Arbitrage price delta
 - Slot granularity (24/48/96 slots)
+- Inverter max power cap (per-model)
+- Both-mode sell with charge energy (low PV confidence)
+- Integration tests: real-world TREX-5/10/25/50 scenarios
+- Tomorrow schedule computation and SOC trajectory
 
 **Not tested**: coordinator.py runtime logic (requires HA mocking). This is a gap — when the coordinator diverges from ems.py, tests won't catch it.
 

--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -114,6 +114,8 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self.tomorrow_planned_slots: int = 0
         self.tomorrow_planned_kwh: float = 0.0
         self._backend_soc_trajectory: list[float] = []
+        self._tomorrow_scheduled_slots: dict[int, str] = {}
+        self._backend_soc_trajectory_tomorrow: list[float] = []
 
         # Always-visible slot info (regardless of price_mode)
         self.available_slots_at_threshold: int = 0
@@ -644,6 +646,8 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self.tomorrow_planned_kwh = result.tomorrow_planned_kwh
         self.schedule_status = result.status
         self._backend_soc_trajectory = result.soc_trajectory
+        self._tomorrow_scheduled_slots = result.tomorrow_scheduled_slots
+        self._backend_soc_trajectory_tomorrow = result.tomorrow_soc_trajectory
 
         if result.price_threshold is not None:
             self.price_threshold = result.price_threshold

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -62,6 +62,8 @@ class ScheduleResult:
     tomorrow_precharge: float = 0.0
     status: str = "off"
     soc_trajectory: list[float] = field(default_factory=list)
+    tomorrow_scheduled_slots: dict[int, str] = field(default_factory=dict)
+    tomorrow_soc_trajectory: list[float] = field(default_factory=list)
 
 
 @dataclass
@@ -714,6 +716,156 @@ def select_unified_charge_slots(
     return today_result, tomorrow_result, tomorrow_charge_kwh
 
 
+def _compute_tomorrow_schedule(
+    config: EMSConfig,
+    state: EMSState,
+    today_result: ScheduleResult,
+    today_soc_trajectory: list[float],
+) -> tuple[dict[int, str], list[float]]:
+    """Compute tomorrow's charge/discharge schedule and SOC trajectory.
+
+    Uses projected midnight SOC from today's trajectory as the starting
+    point.  Charge slots come from the unified selection (already stored
+    in today_result).  Sell slots are computed fresh using the same
+    profitability filter and SOC validation as today.
+
+    Returns (tomorrow_scheduled_slots, tomorrow_soc_trajectory).
+    """
+    tomorrow_prices = state.slot_prices_tomorrow
+    if not tomorrow_prices or config.grid_mode == "off":
+        return {}, []
+
+    num_slots = len(tomorrow_prices)
+    minutes_per_slot = (24 * 60) / num_slots
+    slot_duration_hours = minutes_per_slot / 60.0
+    energy_per_slot = config.safe_power_kw * slot_duration_hours
+    effective_per_slot = energy_per_slot * config.efficiency
+    round_trip_eff = config.efficiency * config.efficiency
+
+    # Projected midnight SOC from today's trajectory (last value)
+    min_kwh = (config.battery_discharge_min_pct / 100.0) * config.battery_capacity_kwh
+    if today_soc_trajectory:
+        midnight_pct = today_soc_trajectory[-1]
+        midnight_kwh = max(min_kwh, (midnight_pct / 100.0) * config.battery_capacity_kwh)
+    else:
+        midnight_kwh = min_kwh
+
+    # Build remaining slots for tomorrow (all are future)
+    remaining = [(i, tomorrow_prices[i]) for i in range(num_slots)
+                 if tomorrow_prices[i] is not None]
+    if not remaining:
+        return {}, []
+
+    # Charge slots: from unified selection stored on today_result
+    scheduled: dict[int, str] = {}
+    charge_indices: set[int] = set()
+
+    # The unified charge selection already picked tomorrow's charge slots.
+    # Reconstruct them: they're the cheapest slots up to tomorrow_planned_slots.
+    if today_result.tomorrow_planned_slots > 0 and config.grid_mode in ("from_grid", "both"):
+        neg = [(i, p) for i, p in remaining if p < 0]
+        non_neg = sorted([(i, p) for i, p in remaining if p >= 0], key=lambda x: x[1])
+        neg_energy = len(neg) * effective_per_slot
+        deficit = today_result.tomorrow_planned_kwh
+        non_neg_needed = math.ceil(max(0, deficit - neg_energy) / effective_per_slot) if effective_per_slot > 0 else 0
+        charge_slots = neg + non_neg[:non_neg_needed]
+        for idx, _ in charge_slots:
+            scheduled[idx] = "charge"
+            charge_indices.add(idx)
+
+    # Synthesize hourly PV for tomorrow (distribute total across daylight 6-18)
+    pv_tomorrow_total = state.pv_forecast_tomorrow or 0.0
+    daylight_hours = list(range(6, 18))
+    pv_per_daylight_hour = pv_tomorrow_total / len(daylight_hours) if daylight_hours else 0.0
+    pv_hourly_tomorrow: dict[int, float] = {}
+    for h in daylight_hours:
+        pv_hourly_tomorrow[h] = pv_per_daylight_hour
+
+    # Sell slots (to_grid or both mode)
+    if config.grid_mode in ("to_grid", "both"):
+        reserve_kwh = calculate_self_consumption_reserve(
+            config.consumption_est_kwh, state.pv_hourly_kwh)
+        reserve_target = _compute_reserve_target(config, reserve_kwh)
+
+        charge_energy = len(charge_indices) * effective_per_slot
+        max_battery_kwh = (config.battery_charge_max_pct / 100.0) * config.battery_capacity_kwh
+
+        # Arbitrage check for tomorrow
+        arbitrage_active = False
+        if config.arbitrage_price_delta > 0 and remaining:
+            prices_vals = [p for _, p in remaining]
+            spread = max(prices_vals) - min(prices_vals)
+            if spread >= config.arbitrage_price_delta:
+                arbitrage_active = True
+
+        if arbitrage_active:
+            sellable = max(0.0, max_battery_kwh - reserve_target) * config.efficiency * 0.85
+        else:
+            peak_kwh = min(max_battery_kwh, midnight_kwh + pv_tomorrow_total + charge_energy)
+            sellable = max(0.0, peak_kwh - reserve_target) * config.efficiency * 0.85
+
+        if sellable > 0:
+            available = [(i, p) for i, p in remaining
+                         if p > 0 and i not in charge_indices]
+            if config.grid_mode == "both" and charge_indices:
+                max_buy = max(tomorrow_prices[i] for i in charge_indices
+                              if tomorrow_prices[i] is not None)
+                min_sell = max_buy / round_trip_eff
+                available = [(i, p) for i, p in available if p >= min_sell]
+
+            available.sort(key=lambda x: -x[1])
+            sell_needed = math.ceil(sellable / energy_per_slot) if energy_per_slot > 0 else 0
+            sell_selected = available[:sell_needed]
+
+            # SOC validation — use synthesized PV hourly for tomorrow
+            consumption_per_slot = config.consumption_est_kwh / num_slots
+            discharge_set = {s[0] for s in sell_selected}
+            _, validated_discharge = _validate_schedule_soc(
+                remaining, charge_indices, discharge_set,
+                midnight_kwh, consumption_per_slot,
+                pv_hourly_tomorrow, minutes_per_slot, 1.0,
+                config.battery_capacity_kwh, reserve_target,
+                energy_per_slot, config.efficiency,
+                consumption_hourly_kwh=state.consumption_hourly_kwh,
+                inverter_max_power_kw=config.inverter_max_power_kw,
+                safe_power_kw=config.safe_power_kw,
+            )
+            for idx, _ in sell_selected:
+                if idx in validated_discharge:
+                    scheduled[idx] = "discharge"
+
+    # SOC trajectory for tomorrow
+    trajectory: list[float] = []
+    cap = config.battery_capacity_kwh
+    soc = midnight_kwh
+
+    for i in range(num_slots):
+        pct = max(0.0, min(100.0, (soc / cap) * 100.0)) if cap > 0 else 0.0
+        trajectory.append(round(pct, 1))
+
+        hour = int((i * minutes_per_slot) / 60)
+        pv_kwh_rate = pv_per_daylight_hour if hour in daylight_hours else 0.0
+        pv_per_slot = pv_kwh_rate * slot_duration_hours
+
+        if state.consumption_hourly_kwh and hour in state.consumption_hourly_kwh:
+            cons = state.consumption_hourly_kwh[hour] * slot_duration_hours
+        else:
+            cons = config.consumption_est_kwh / num_slots
+
+        delta = pv_per_slot - cons
+        action = scheduled.get(i)
+        if action == "charge":
+            grid_kw = min(config.safe_power_kw,
+                          max(0.0, config.inverter_max_power_kw - pv_kwh_rate))
+            delta += grid_kw * slot_duration_hours * config.efficiency
+        elif action == "discharge" and soc > min_kwh:
+            delta -= min(energy_per_slot, soc - min_kwh)
+
+        soc = max(min_kwh, min(cap, soc + delta))
+
+    return scheduled, trajectory
+
+
 def calculate_schedule(config: EMSConfig, state: EMSState) -> ScheduleResult:
     """Calculate optimal charge/discharge schedule.
 
@@ -803,6 +955,14 @@ def calculate_schedule(config: EMSConfig, state: EMSState) -> ScheduleResult:
         result.scheduled_slots,
         config, state,
     )
+
+    # Compute tomorrow's schedule and trajectory (if tomorrow prices exist)
+    if state.slot_prices_tomorrow:
+        tmr_slots, tmr_traj = _compute_tomorrow_schedule(
+            config, state, result, result.soc_trajectory,
+        )
+        result.tomorrow_scheduled_slots = tmr_slots
+        result.tomorrow_soc_trajectory = tmr_traj
 
     return result
 

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -584,15 +584,38 @@ class FelicityEMSCard extends LitElement {
       showTomorrow = false;
     }
 
-    // For tomorrow, run a forecast simulation too (no current-slot offset)
     // Keep today's sim for unified stats (tomorrowChargeCount, tomorrowPlanned)
     this._todaySimResult = useBackendSchedule ? { ...simResult, slots: todaySlotData } : simResult;
     let displayData, displayThreshold;
     if (showTomorrow) {
-      const tmrSim = this._simulateScheduleTomorrow(tomorrowSlotData, this._simOverrides);
-      displayData = tmrSim?.slots ?? tomorrowSlotData;
-      displayThreshold = tmrSim?.threshold;
-      this._simResult = tmrSim;  // stats reflect tomorrow preview
+      const useBackendTomorrow = !hasAnyOverrides && tomorrowSlotData?.some(s => s.action != null);
+      if (useBackendTomorrow) {
+        // Backend is authoritative — use its schedule directly
+        const sim = this._getAttr("schedule_status", "sim_params") || {};
+        const safeMaxPower = this._getNumericState("safe_max_power") || 5000;
+        const powerKw = Math.max(1, safeMaxPower / 1000);
+        const granMin = this._getAttr("schedule_status", "slot_granularity_min") || Math.round((24 * 60) / tomorrowSlotData.length);
+        const slotDur = granMin / 60;
+        const eff = sim.efficiency || 0.90;
+        const effectivePerSlot = powerKw * slotDur * eff;
+        const chargeCount = tomorrowSlotData.filter(s => s.action === "charge").length;
+        const dischargeCount = tomorrowSlotData.filter(s => s.action === "discharge").length;
+        displayData = tomorrowSlotData;
+        displayThreshold = null;
+        this._simResult = {
+          slots: tomorrowSlotData,
+          chargeCount,
+          dischargeCount,
+          planned: Math.round((chargeCount * effectivePerSlot + dischargeCount * powerKw * slotDur) * 100) / 100,
+          threshold: null,
+        };
+      } else {
+        // Overrides active — run client-side simulation for preview
+        const tmrSim = this._simulateScheduleTomorrow(tomorrowSlotData, this._simOverrides);
+        displayData = tmrSim?.slots ?? tomorrowSlotData;
+        displayThreshold = tmrSim?.threshold;
+        this._simResult = tmrSim;
+      }
     } else {
       displayData = useBackendSchedule ? todaySlotData : (simResult?.slots ?? todaySlotData);
       displayThreshold = simResult?.threshold;
@@ -776,10 +799,14 @@ class FelicityEMSCard extends LitElement {
     // Prefer backend-computed trajectory when no overrides are active.
     // Fall back to client-side simulation when user is previewing via
     // sliders (_simOverrides) or manual slot clicks (_slotOverrides).
-    const backendTrajectory = (!hasAnyOverrides && !showTomorrow)
-      ? ((this._getAttr("schedule_status", "sim_params") || {}).backend_soc_trajectory || null)
-      : null;
-    const socTrajectory = (backendTrajectory && backendTrajectory.length === numSlots)
+    let backendTrajectory = null;
+    if (!hasAnyOverrides) {
+      const simParams = this._getAttr("schedule_status", "sim_params") || {};
+      backendTrajectory = showTomorrow
+        ? (simParams.backend_soc_trajectory_tomorrow || null)
+        : (simParams.backend_soc_trajectory || null);
+    }
+    const socTrajectory = (backendTrajectory && backendTrajectory.length >= numSlots)
       ? backendTrajectory
       : this._computeSocTrajectory(displayData, showTomorrow);
     const socHistory = this._getAttr("schedule_status", "soc_history") || {};

--- a/custom_components/ha_felicity/sensor.py
+++ b/custom_components/ha_felicity/sensor.py
@@ -139,15 +139,16 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
                     "action": action,
                 })
 
-        # Build tomorrow's slot data (prices only, no schedule yet)
+        # Build tomorrow's slot data with backend-computed actions
         tomorrow_slot_data = []
         tomorrow_prices = self.coordinator.slot_prices_tomorrow
+        tomorrow_scheduled = self.coordinator._tomorrow_scheduled_slots or {}
         if tomorrow_prices:
             for i, price in enumerate(tomorrow_prices):
                 tomorrow_slot_data.append({
                     "slot": i,
                     "price": round(price, 4) if price is not None else None,
-                    "action": None,
+                    "action": tomorrow_scheduled.get(i),
                 })
 
         return {
@@ -186,6 +187,7 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
                 "pv_confidence": getattr(self.coordinator, '_last_pv_confidence', 1.0),
                 "consumption_hourly_profile": self.coordinator._hourly_consumption_profile or {},
                 "backend_soc_trajectory": self.coordinator._backend_soc_trajectory,
+                "backend_soc_trajectory_tomorrow": self.coordinator._backend_soc_trajectory_tomorrow,
                 "inverter_max_power_kw": self.coordinator._inverter_max_power_kw,
             },
             "soc_history": self.coordinator._soc_history,

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -45,6 +45,7 @@ _calculate_pv_confidence = ems._calculate_pv_confidence
 _project_soc_trajectory = ems._project_soc_trajectory
 _validate_schedule_soc = ems._validate_schedule_soc
 _compute_reserve_target = ems._compute_reserve_target
+_compute_tomorrow_schedule = ems._compute_tomorrow_schedule
 
 
 # ---------------------------------------------------------------------------
@@ -2595,3 +2596,391 @@ class TestBothModeSellWithChargeEnergy:
         result = calculate_schedule(config, state)
         sell_count = sum(1 for v in result.scheduled_slots.values() if v == "discharge")
         assert sell_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests: Real-World Scenarios
+# ---------------------------------------------------------------------------
+
+class TestIntegrationCustomerScenarios:
+    """End-to-end tests mimicking real customer configurations.
+
+    Each test reproduces a specific customer setup (TREX model, battery size,
+    consumption, PV, prices) and asserts the schedule meets operational
+    requirements: SOC never below min, sell slots exist when surplus is
+    available, charge slots are reasonable, tomorrow schedule is computed.
+    """
+
+    def _assert_soc_never_below_min(self, result, config, state):
+        """Verify the SOC trajectory never dips below discharge_min."""
+        if not result.soc_trajectory:
+            return
+        min_allowed = config.battery_discharge_min_pct
+        for i, soc in enumerate(result.soc_trajectory):
+            assert soc >= min_allowed - 0.5, (
+                f"SOC at slot {i} is {soc}%, below min {min_allowed}%"
+            )
+
+    def _assert_no_flat_trajectory(self, result):
+        """Verify SOC trajectory isn't completely flat (consumption should drain)."""
+        if not result.soc_trajectory or len(result.soc_trajectory) < 3:
+            return
+        unique = set(round(s, 0) for s in result.soc_trajectory)
+        assert len(unique) > 1, "SOC trajectory is flat — consumption isn't draining battery"
+
+    def test_trex25_both_mode_low_battery_no_pv(self):
+        """Customer: TREX-25, 60kWh, both mode, 28% SOC, 0 PV produced.
+
+        SOC starts below reserve target, so SOC validation correctly prunes
+        sell slots (battery must stay above reserve at every point).
+        Charges to cover overnight needs.
+        """
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=20.0,
+            battery_charge_max_pct=100.0,
+            consumption_est_kwh=13.0,
+            safe_power_kw=12.5,
+            inverter_max_power_kw=25.0,
+            efficiency=0.90,
+        )
+        prices_today = (
+            [0.02, 0.02, 0.03, 0.03, 0.04, 0.05]
+            + [0.08, 0.10, 0.12, 0.14, 0.15, 0.14]
+            + [0.12, 0.10, 0.09, 0.08, 0.07, 0.10]
+            + [0.18, 0.22, 0.25, 0.20, 0.15, 0.08]
+        )
+        state = default_state(
+            battery_soc_pct=28.0,
+            slot_prices_today=prices_today,
+            pv_hourly_kwh=make_pv_hourly(39.0),
+            pv_forecast_remaining=24.0,
+            pv_forecast_today=39.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=10,
+            current_minute=0,
+        )
+        result = calculate_schedule(config, state)
+        charges = sum(1 for v in result.scheduled_slots.values() if v == "charge")
+        assert charges > 0, "Should charge — battery is below reserve"
+        self._assert_soc_never_below_min(result, config, state)
+        self._assert_no_flat_trajectory(result)
+
+    def test_trex25_both_mode_high_battery_sells(self):
+        """TREX-25, battery above reserve — should sell at peak prices."""
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=13.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=25.0,
+        )
+        prices = [0.02] * 6 + [0.05] * 6 + [0.08] * 6 + [0.15] * 6
+        state = default_state(
+            battery_soc_pct=80.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(30.0),
+            pv_forecast_remaining=15.0,
+            pv_forecast_today=30.0,
+            pv_actual_today_kwh=15.0,
+            current_hour=12,
+        )
+        result = calculate_schedule(config, state)
+        sells = sum(1 for v in result.scheduled_slots.values() if v == "discharge")
+        assert sells > 0, "Should sell — battery is well above reserve"
+        self._assert_soc_never_below_min(result, config, state)
+
+    def test_trex10_from_grid_cloudy_day(self):
+        """TREX-10, 20kWh battery, from_grid, cloudy day (PV conf ~0.2).
+
+        High PV forecast (30 kWh) but only 1.5 kWh produced by noon
+        drops confidence, forcing grid charging.
+        """
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=20.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=10.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+        )
+        prices = [0.05] * 6 + [0.10] * 6 + [0.15] * 6 + [0.25] * 6
+        state = default_state(
+            battery_soc_pct=35.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(30.0),
+            pv_forecast_remaining=20.0,
+            pv_forecast_today=30.0,
+            pv_actual_today_kwh=1.5,
+            current_hour=12,
+        )
+        result = calculate_schedule(config, state)
+        charges = sum(1 for v in result.scheduled_slots.values() if v == "charge")
+        assert charges > 0, "Should charge — cloudy day with low PV confidence"
+        self._assert_soc_never_below_min(result, config, state)
+
+    def test_trex5_to_grid_sunny_day(self):
+        """TREX-5, 10kWh battery, to_grid only, sunny day.
+
+        Expected: sell slots at peak prices, no charge slots.
+        """
+        config = default_config(
+            grid_mode="to_grid",
+            battery_capacity_kwh=10.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=8.0,
+            safe_power_kw=3.0,
+            inverter_max_power_kw=5.0,
+        )
+        prices = (
+            [0.05] * 6 + [0.10] * 4 + [0.08] * 4
+            + [0.10] * 2 + [0.15] * 2 + [0.25, 0.30, 0.28, 0.20, 0.12, 0.08]
+        )
+        state = default_state(
+            battery_soc_pct=80.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(20.0),
+            pv_forecast_remaining=10.0,
+            pv_forecast_today=20.0,
+            pv_actual_today_kwh=10.0,
+            current_hour=12,
+        )
+        result = calculate_schedule(config, state)
+        charges = sum(1 for v in result.scheduled_slots.values() if v == "charge")
+        sells = sum(1 for v in result.scheduled_slots.values() if v == "discharge")
+        assert charges == 0, "to_grid mode should not charge"
+        assert sells > 0, "Should sell at evening peak"
+        self._assert_soc_never_below_min(result, config, state)
+
+    def test_trex50_both_mode_with_arbitrage(self):
+        """TREX-50, 100kWh battery, both mode with arbitrage delta.
+
+        No PV scenario: all charge comes from grid, creating large surplus
+        above reserve for selling.
+        """
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=100.0,
+            battery_discharge_min_pct=15.0,
+            battery_charge_max_pct=95.0,
+            consumption_est_kwh=30.0,
+            safe_power_kw=25.0,
+            inverter_max_power_kw=50.0,
+            arbitrage_price_delta=0.10,
+        )
+        prices = [0.02] * 8 + [0.05] * 4 + [0.04] * 4 + [0.15, 0.20, 0.25, 0.30, 0.28, 0.18, 0.10, 0.05]
+        state = default_state(
+            battery_soc_pct=60.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh={},
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=0.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=6,
+        )
+        result = calculate_schedule(config, state)
+        charges = sum(1 for v in result.scheduled_slots.values() if v == "charge")
+        sells = sum(1 for v in result.scheduled_slots.values() if v == "discharge")
+        assert charges > 0, "Should charge for arbitrage"
+        assert sells > 0, "Should sell at evening peak — battery well above reserve"
+        self._assert_soc_never_below_min(result, config, state)
+
+    def test_trex25_negative_prices_with_pv(self):
+        """TREX-25 with negative prices during high PV: negative-price
+        charge slots shouldn't overflow battery when PV is already filling it.
+        """
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=15.0,
+            safe_power_kw=12.5,
+            inverter_max_power_kw=25.0,
+        )
+        prices = [0.10] * 6 + [-0.05, -0.03, -0.02, -0.01] + [0.08] * 8 + [0.15] * 6
+        state = default_state(
+            battery_soc_pct=70.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(45.0),
+            pv_forecast_remaining=30.0,
+            pv_forecast_today=45.0,
+            pv_actual_today_kwh=15.0,
+            current_hour=9,
+        )
+        result = calculate_schedule(config, state)
+        if result.soc_trajectory:
+            max_soc = max(result.soc_trajectory)
+            assert max_soc <= 100.5, f"SOC exceeds 100%: {max_soc}"
+        self._assert_soc_never_below_min(result, config, state)
+
+    def test_early_morning_schedule_full_day(self):
+        """Schedule at midnight (hour 0) with all slots remaining.
+
+        Verifies the algorithm handles the full-day case without errors
+        and produces a valid SOC trajectory.
+        """
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=20.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=12.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+        )
+        prices = make_prices(48, pattern="v_shape")
+        state = default_state(
+            battery_soc_pct=50.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(18.0),
+            pv_forecast_remaining=18.0,
+            pv_forecast_today=18.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=0,
+            current_minute=0,
+        )
+        result = calculate_schedule(config, state)
+        assert result.soc_trajectory, "Should produce SOC trajectory"
+        assert len(result.soc_trajectory) == 48, "Should have one entry per slot"
+        self._assert_soc_never_below_min(result, config, state)
+
+
+class TestTomorrowScheduleIntegration:
+    """Tests for the tomorrow schedule computation via calculate_schedule."""
+
+    def test_tomorrow_schedule_computed_when_prices_available(self):
+        """When tomorrow prices exist and deficit requires tomorrow charge,
+        schedule includes tomorrow slots."""
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=20.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=10.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+        )
+        today_prices = [0.20] * 20 + [0.25, 0.30, 0.25, 0.20]
+        tomorrow_prices = [0.02] * 8 + [0.10] * 8 + [0.25] * 4 + [0.08] * 4
+        state = default_state(
+            battery_soc_pct=30.0,
+            slot_prices_today=today_prices,
+            slot_prices_tomorrow=tomorrow_prices,
+            pv_hourly_kwh=make_pv_hourly(15.0),
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=15.0,
+            pv_forecast_tomorrow=12.0,
+            pv_actual_today_kwh=15.0,
+            current_hour=20,
+        )
+        result = calculate_schedule(config, state)
+        assert result.tomorrow_scheduled_slots, "Should have tomorrow scheduled slots"
+        assert result.tomorrow_soc_trajectory, "Should have tomorrow SOC trajectory"
+        assert len(result.tomorrow_soc_trajectory) == 24
+
+    def test_tomorrow_schedule_empty_when_grid_off(self):
+        """No tomorrow schedule when grid_mode is off."""
+        config = default_config(grid_mode="off")
+        state = default_state(
+            slot_prices_tomorrow=[0.10] * 24,
+            pv_forecast_tomorrow=15.0,
+        )
+        result = calculate_schedule(config, state)
+        assert not result.tomorrow_scheduled_slots
+
+    def test_tomorrow_schedule_empty_when_no_prices(self):
+        """No tomorrow schedule when tomorrow prices are unavailable."""
+        config = default_config(grid_mode="from_grid")
+        state = default_state(slot_prices_tomorrow=None)
+        result = calculate_schedule(config, state)
+        assert not result.tomorrow_scheduled_slots
+        assert not result.tomorrow_soc_trajectory
+
+    def test_tomorrow_trajectory_starts_from_today_end(self):
+        """Tomorrow's SOC trajectory should start near today's ending SOC."""
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=20.0,
+            consumption_est_kwh=10.0,
+            safe_power_kw=5.0,
+        )
+        today_prices = make_prices(24, pattern="cheap_morning")
+        tomorrow_prices = make_prices(24, pattern="v_shape")
+        state = default_state(
+            battery_soc_pct=60.0,
+            slot_prices_today=today_prices,
+            slot_prices_tomorrow=tomorrow_prices,
+            pv_hourly_kwh=make_pv_hourly(15.0),
+            pv_forecast_remaining=8.0,
+            pv_forecast_today=15.0,
+            pv_forecast_tomorrow=12.0,
+            pv_actual_today_kwh=7.0,
+            current_hour=12,
+        )
+        result = calculate_schedule(config, state)
+        if result.soc_trajectory and result.tomorrow_soc_trajectory:
+            today_end = result.soc_trajectory[-1]
+            tomorrow_start = result.tomorrow_soc_trajectory[0]
+            assert abs(today_end - tomorrow_start) < 15, (
+                f"Tomorrow start SOC ({tomorrow_start}%) diverges from "
+                f"today end SOC ({today_end}%) by more than 15%"
+            )
+
+    def test_tomorrow_both_mode_has_sell_slots(self):
+        """Tomorrow schedule in both mode: charge cheap slots, sell at peak."""
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=100.0,
+            battery_discharge_min_pct=15.0,
+            consumption_est_kwh=10.0,
+            safe_power_kw=10.0,
+            inverter_max_power_kw=25.0,
+        )
+        today_prices = [0.15] * 22 + [0.25, 0.30]
+        tomorrow_prices = [0.01] * 8 + [0.04] * 4 + [0.06] * 4 + [0.20, 0.30, 0.40, 0.35] + [0.08] * 4
+        state = default_state(
+            battery_soc_pct=20.0,
+            slot_prices_today=today_prices,
+            slot_prices_tomorrow=tomorrow_prices,
+            pv_hourly_kwh=make_pv_hourly(20.0),
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=20.0,
+            pv_forecast_tomorrow=30.0,
+            pv_actual_today_kwh=20.0,
+            current_hour=22,
+        )
+        result = calculate_schedule(config, state)
+        tmr_charges = sum(1 for v in result.tomorrow_scheduled_slots.values() if v == "charge")
+        tmr_sells = sum(1 for v in result.tomorrow_scheduled_slots.values() if v == "discharge")
+        assert tmr_charges > 0, "Tomorrow should have charge slots"
+        assert tmr_sells > 0, "Tomorrow should have sell slots at peak prices"
+
+    def test_tomorrow_soc_never_below_min(self):
+        """Tomorrow's SOC trajectory should never go below discharge_min."""
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=40.0,
+            battery_discharge_min_pct=25.0,
+            consumption_est_kwh=20.0,
+            safe_power_kw=8.0,
+            inverter_max_power_kw=10.0,
+        )
+        today_prices = make_prices(24, pattern="rising")
+        tomorrow_prices = [0.03] * 6 + [0.10] * 6 + [0.05] * 6 + [0.20] * 6
+        state = default_state(
+            battery_soc_pct=45.0,
+            slot_prices_today=today_prices,
+            slot_prices_tomorrow=tomorrow_prices,
+            pv_hourly_kwh=make_pv_hourly(20.0),
+            pv_forecast_remaining=10.0,
+            pv_forecast_today=20.0,
+            pv_forecast_tomorrow=18.0,
+            pv_actual_today_kwh=10.0,
+            current_hour=12,
+        )
+        result = calculate_schedule(config, state)
+        min_allowed = config.battery_discharge_min_pct
+        for i, soc in enumerate(result.tomorrow_soc_trajectory):
+            assert soc >= min_allowed - 1.0, (
+                f"Tomorrow SOC at slot {i} is {soc}%, below min {min_allowed}%"
+            )


### PR DESCRIPTION
- Frontend uses backend tomorrow schedule and SOC trajectory when no overrides active, eliminating divergence from client-side simulation
- Fix tomorrow sell slots: pass synthesized PV hourly to SOC validation so discharge slots aren't incorrectly pruned during daylight hours
- Add 13 integration tests covering real-world TREX-5/10/25/50 scenarios and tomorrow schedule computation (130 tests total)

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF