### PR TITLE
Drop phantom tomorrow charge slot when battery is already full

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,15 @@ negative-price income is pure profit.  When PV is insufficient to cause
 overflow on its own, negative-price charge slots are still pruned to
 prevent forced grid export at penalty rates.
 
+**Phantom-charge detection**: when a charge slot is scheduled at a
+moment the battery is already at capacity (`soc_before >= capacity - 0.01`),
+the inverter physically cannot store the energy (BMS rejects).  These
+slots are dropped regardless of price — even negative-price slots,
+because the income doesn't materialise if no grid energy is drawn.
+The validation simulates forward through PV-only overflows (clamping
+soc and continuing) instead of breaking on the first PV-caused
+violation, which lets it detect phantom charges later in the day.
+
 ### Arbitrage Price Delta (both mode)
 
 When `arbitrage_price_delta > 0` and `max_remaining_price - min_remaining_price >= delta`:

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -490,14 +490,31 @@ def _validate_schedule_soc(
         surplus = pv_per_slot - cons
         if surplus > 0:
             pv_surplus_total += surplus
-    pv_fills_battery = pv_surplus_total >= (battery_capacity - current_kwh) * 0.9
+    # pv_surplus_total is logged when a negative-price slot is kept due
+    # to PV-caused overflow.  The actual exemption check is per-slot
+    # (violation_pv_caused) below.
+
+    # PV-overflow exemption only applies when the battery has real room
+    # to fill.  When current_kwh is already at/near capacity, the exemption
+    # would preserve negative-price slots that the inverter can't actually
+    # execute (BMS rejects charging a full battery), producing phantom
+    # schedule entries.
+    pv_fills_battery = (
+        current_kwh < battery_capacity * 0.95
+        and pv_surplus_total >= (battery_capacity - current_kwh) * 0.9
+    )
 
     max_iterations = len(charge_slots) + len(discharge_slots) + 1
 
     for _ in range(max_iterations):
         violation_slot: int | None = None
         violation_type: str | None = None  # "low" or "high"
-        discharge_seen = False  # track if a discharge happened before violation
+        # Whether the charge action at the violation slot is wasted: when
+        # the battery is already at capacity entering a charge slot, the
+        # inverter can't physically store any of the grid energy.  Such
+        # phantom slots must be dropped regardless of price.
+        violation_charge_wasted = False
+        discharge_seen = False
 
         soc = current_kwh
         for slot_idx, _ in remaining:
@@ -510,39 +527,61 @@ def _validate_schedule_soc(
             else:
                 cons = consumption_per_slot
             delta = pv_per_slot - cons
+            charge_contribution = 0.0
             if slot_idx in charge_slots:
                 if inverter_max_power_kw > 0:
                     grid_kw = min(safe_power_kw or energy_per_slot / (minutes_per_slot / 60.0),
                                   max(0.0, inverter_max_power_kw - pv_kwh * pv_confidence))
-                    delta += grid_kw * (minutes_per_slot / 60.0) * efficiency
+                    charge_contribution = grid_kw * (minutes_per_slot / 60.0) * efficiency
                 else:
-                    delta += energy_per_slot * efficiency
+                    charge_contribution = energy_per_slot * efficiency
+                delta += charge_contribution
             if slot_idx in discharge_slots:
                 delta -= energy_per_slot
                 discharge_seen = True
 
-            soc = soc + delta
+            soc_before = soc
+            soc_ideal = soc + delta
 
-            # Check bounds BEFORE clamping — charging a full battery wastes
-            # energy, discharging an empty one is impossible.
-            if soc < min_kwh - 0.01:
-                # If no discharge happened before this point, the low SOC
-                # is inherent (battery starts below reserve/min) — not
-                # caused by any scheduled discharge.  Clamp and continue
-                # rather than pruning unrelated future discharge slots.
+            # Low-bound check: SOC dipping below min is always a violation.
+            if soc_ideal < min_kwh - 0.01:
                 if not discharge_seen:
-                    soc = max(0.0, min(battery_capacity, soc))
+                    soc = max(0.0, min(battery_capacity, soc_ideal))
                     continue
                 violation_slot = slot_idx
                 violation_type = "low"
                 break
-            if soc > battery_capacity + 0.01:
+            if soc_ideal > battery_capacity + 0.01:
+                # Determine causality.  If PV alone (no charge action)
+                # would also overflow at this slot, the natural BMS
+                # behaviour is to spill the excess — clamp soc and keep
+                # simulating to detect any genuine charge-caused issues
+                # at later slots (e.g., a phantom charge during clamped
+                # hours that would otherwise be missed).
+                soc_no_charge = soc_before + (delta - charge_contribution)
+                pv_alone_overflows = soc_no_charge > battery_capacity + 0.01
+                if pv_alone_overflows:
+                    # Phantom charge: action present on already-full battery.
+                    # Drop regardless of price — the energy can't land.
+                    if (charge_contribution > 0
+                            and soc_before >= battery_capacity - 0.01):
+                        violation_charge_wasted = True
+                        violation_slot = slot_idx
+                        violation_type = "high"
+                        break
+                    # PV-only spill: clamp and continue simulating.
+                    soc = battery_capacity
+                    continue
+                # Charge action contributes to / causes overflow.
+                if (charge_contribution > 0
+                        and soc_before >= battery_capacity - 0.01):
+                    violation_charge_wasted = True
                 violation_slot = slot_idx
                 violation_type = "high"
                 break
 
-            # Clamp to physical limits for subsequent slot calculations
-            soc = max(0.0, min(battery_capacity, soc))
+            # Clamp for next iteration
+            soc = max(0.0, min(battery_capacity, soc_ideal))
 
         if violation_slot is None:
             break  # Schedule is valid
@@ -580,10 +619,14 @@ def _validate_schedule_soc(
                 ]
             if not candidates:
                 # Only negative-price slots remain.  If PV alone would
-                # fill the battery, the overflow is PV-caused — pruning
-                # negative-price slots won't prevent it, and the income
-                # from charging at negative prices is pure profit.
-                if pv_fills_battery:
+                # fill the battery (and the battery has room to fill),
+                # the overflow is PV-caused — pruning negative-price
+                # slots won't prevent it, and the income from charging
+                # at negative prices is pure profit.
+                # EXCEPTION: when the violation slot's charge action is
+                # wasted (battery was already at capacity entering it),
+                # the negative-price slot is phantom — drop it anyway.
+                if pv_fills_battery and not violation_charge_wasted:
                     _LOGGER.debug(
                         "SOC validation: keeping negative-price charge slots — "
                         "PV surplus (%.1f kWh) fills battery anyway",
@@ -858,6 +901,34 @@ def _compute_tomorrow_schedule(
     pv_hourly_tomorrow: dict[int, float] = {}
     for h in daylight_hours:
         pv_hourly_tomorrow[h] = pv_per_daylight_hour
+
+    # Validate tomorrow's charge slots: drop any that would overflow.
+    # Without this, a negative or near-zero-price slot picked by the
+    # unified selector ends up scheduled even when SOC is already pegged
+    # at 100% from PV — a phantom "charge" the inverter can't execute.
+    if charge_indices:
+        consumption_per_slot_t = config.consumption_est_kwh / num_slots
+        validated_charge_t, _ = _validate_schedule_soc(
+            remaining, set(charge_indices), set(),
+            midnight_kwh, consumption_per_slot_t,
+            pv_hourly_tomorrow, minutes_per_slot, 1.0,
+            config.battery_capacity_kwh, min_kwh,
+            energy_per_slot, config.efficiency,
+            consumption_hourly_kwh=state.consumption_hourly_kwh,
+            inverter_max_power_kw=config.inverter_max_power_kw,
+            safe_power_kw=config.safe_power_kw,
+        )
+        dropped_t = [i for i in charge_indices if i not in validated_charge_t]
+        for idx in dropped_t:
+            scheduled.pop(idx, None)
+            charge_indices.discard(idx)
+        if dropped_t:
+            _LOGGER.info(
+                "Tomorrow schedule: dropped %d charge slot(s) that would "
+                "overflow battery (midnight_kwh=%.1f, capacity=%.1f): %s",
+                len(dropped_t), midnight_kwh, config.battery_capacity_kwh,
+                sorted(dropped_t),
+            )
 
     # Sell slots (to_grid or both mode)
     if config.grid_mode in ("to_grid", "both"):

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -2733,13 +2733,15 @@ class TestIntegrationCustomerScenarios:
     def test_trex5_to_grid_sunny_day(self):
         """TREX-5, 10kWh battery, to_grid only, sunny day.
 
-        Expected: sell slots at peak prices, no charge slots.
+        Expected: sell slots at peak prices, no charge slots, SOC stays
+        above reserve target (consumption tuned so reserve doesn't block
+        the evening sell).
         """
         config = default_config(
             grid_mode="to_grid",
             battery_capacity_kwh=10.0,
             battery_discharge_min_pct=20.0,
-            consumption_est_kwh=8.0,
+            consumption_est_kwh=4.0,  # smaller reserve to leave room for sell
             safe_power_kw=3.0,
             inverter_max_power_kw=5.0,
         )
@@ -3487,4 +3489,76 @@ class TestPVForecastFallback:
         assert fb_charges <= no_fb_charges, (
             f"With PV fallback ({fb_charges} charges), should plan no more "
             f"grid charging than without ({no_fb_charges})"
+        )
+
+
+class TestTomorrowFullBatteryNoPhantomCharge:
+    """When battery is already full and tomorrow's PV will keep it there,
+    no charge slots should be scheduled — the inverter can't charge a
+    full battery.  Regression test for the negative-price slot getting
+    scheduled at hour 16 when SOC was 100% all day."""
+
+    def test_no_tomorrow_charge_when_battery_full_with_pv(self):
+        """Battery starts full, PV tomorrow keeps it full → no charge slots."""
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=35.0,
+            battery_charge_max_pct=100.0,
+            consumption_est_kwh=30.9,
+            safe_power_kw=8.0,
+        )
+        # One slot has a slightly negative price tomorrow (would otherwise
+        # be auto-selected by negative-slot pickup)
+        prices_today = [0.20] * 24
+        prices_tomorrow = [0.20] * 16 + [-0.01] + [0.20] * 7
+        state = default_state(
+            battery_soc_pct=100.0,
+            slot_prices_today=prices_today,
+            slot_prices_tomorrow=prices_tomorrow,
+            pv_hourly_kwh=make_pv_hourly(48.0),
+            pv_forecast_remaining=10.2,
+            pv_forecast_today=48.0,
+            pv_forecast_tomorrow=40.0,
+            pv_actual_today_kwh=37.9,
+            current_hour=15,
+        )
+        result = calculate_schedule(config, state)
+        tomorrow_charges = sum(
+            1 for v in result.tomorrow_scheduled_slots.values() if v == "charge"
+        )
+        assert tomorrow_charges == 0, (
+            f"Battery full + PV keeps it full → no tomorrow charge slots, "
+            f"got {tomorrow_charges}: {result.tomorrow_scheduled_slots}"
+        )
+
+    def test_negative_charge_kept_when_battery_has_room(self):
+        """The fix shouldn't break the legitimate case: when battery has
+        actual room to fill and PV would overflow it, negative-price slots
+        are still kept (the income is pure profit)."""
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=20.0,
+            consumption_est_kwh=10.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+        )
+        prices = [0.05] * 7 + [-0.46, -0.30, -0.20] + [0.05] * 4 + [0.10] * 4 + [0.15] * 6
+        state = default_state(
+            battery_soc_pct=29.0,  # plenty of headroom
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(65.0),
+            pv_forecast_remaining=64.7,
+            pv_forecast_today=65.0,
+            pv_actual_today_kwh=0.3,
+            current_hour=7,
+        )
+        result = calculate_schedule(config, state)
+        charges = {k for k, v in result.scheduled_slots.items() if v == "charge"}
+        neg_slots = {i for i, p in enumerate(prices) if p < 0 and i >= 7}
+        neg_charged = charges & neg_slots
+        assert len(neg_charged) == len(neg_slots), (
+            f"With headroom, all negative-price slots should still charge: "
+            f"got {len(neg_charged)} of {len(neg_slots)}"
         )


### PR DESCRIPTION
The user reported a charge slot scheduled at hour 16 of tomorrow's forecast even though the SOC trajectory showed 100% throughout the day. The slot was the lowest-priced (slightly negative) and was being kept by the SOC-validation PV-overflow exemption.

Root cause: the validation broke on the first PV-only overflow at slot 14 and never reached slot 16 to evaluate that the charge there couldn't physically land in an already-full battery.  The PV-fills- battery exemption then kept the slot.

Fix: in _validate_schedule_soc, when a high-bound violation is caused by PV alone (soc_before + delta - charge_contribution > capacity), clamp soc and continue simulating instead of breaking immediately.  This lets the validation reach later slots and detect phantom charges (charges scheduled when soc_before is already at capacity).  Such slots are dropped regardless of price — the inverter can't store the energy, so the negative-price income doesn't materialise.

Also added validation of charge slots in _compute_tomorrow_schedule (previously only discharges were validated for tomorrow), so the phantom detection actually applies to tomorrow's schedule.

One existing integration test (test_trex5_to_grid_sunny_day) was masking a legitimate reserve-target violation due to the early-exit behaviour; updated its consumption_est to leave room for the sell.

148 tests pass.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF