### PR TITLE
Add negative-price strategies + switch config sliders to input boxes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ This prevents the SOC prediction from assuming unrealistic charge rates
 | battery_cycle_cost_eur_kwh | 0.0 | Wear cost; added to min sell price |
 | optimization_priority | "cost" | cost / longevity / self_consumption |
 | block_export_on_negative_price | True | Skip sell scheduling at p < 0 |
+| charge_to_full_on_negative_price | False | Schedule every p<0 slot (revenue at p<0); accepts forced PV curtailment |
+| discharge_to_make_room_for_negative_price | False | Pre-emptively discharge before p<0 PV windows so PV can fill the battery |
 
 The coordinator applies a SOH factor to nominal `battery_capacity_kwh`
 before constructing `EMSConfig` — ems.py treats the capacity as
@@ -260,6 +262,49 @@ max_today_slots = floor(headroom / effective_per_slot)
 # SOC validation prunes only when PV alone wouldn't fill the battery.
 ```
 
+### Negative-Price Strategies (charge_to_full / discharge_to_make_room)
+
+Two orthogonal opt-in flags that change how negative-price slots are
+handled.  Both are off by default and compose with all grid modes
+(from_grid, to_grid, both).
+
+**`charge_to_full_on_negative_price`** — acts *during* p<0 slots
+- In `_schedule_from_grid` / `_schedule_both`, after the normal
+  cheapest-slot selection, every negative-price slot in the remaining
+  window is added to the charge set (deduplicated).
+- `_validate_schedule_soc` is called with `keep_all_negative_charges=True`.
+  When set, negative-price slots are exempt from overflow pruning even
+  when PV alone wouldn't fill the battery (the legacy `pv_fills_battery`
+  exemption is broadened to "all negatives").
+- Phantom-charge slots (battery already at capacity entering the slot)
+  are kept too — the inverter may try to charge and the BMS will gate
+  it.  No harm; the schedule reflects user intent.
+- Trade-off: the user accepts some forced PV curtailment in exchange
+  for guaranteed revenue at every p<0 slot.
+
+**`discharge_to_make_room_for_negative_price`** — acts *before* p<0 slots
+- New helper `_select_discharges_for_pv_headroom` runs after charge
+  selection.  Walks the SOC trajectory forward; whenever a negative-
+  price slot with PV surplus would overflow the battery, schedules
+  discharge in the *most expensive* earlier positive-price slot to
+  create headroom.
+- Validity: SOC must never drop below the absolute `min_kwh` floor
+  (hardware safety), and end-of-day SOC must remain >= reserve_target
+  (overnight coverage).  Temporary dips below reserve during the day
+  are allowed — the negative-window PV will refill the battery.
+- Works in `from_grid` mode (which normally never discharges) as well
+  as `to_grid` / `both`.  In `both` mode, the make-room discharges
+  are merged with the regular sell-side selection (sells take
+  precedence on conflicting slots).
+
+**Composition**: when both flags are on, make-room discharges are
+scheduled before negative windows, then charge slots fire during the
+negatives.  Net effect: maximum profit on negative-price days
+(discharge at peak + buy at p<0 + PV fills the cleared battery).
+
+Exposed as off/on select entities (`HA_FelicitySpecialModeSelect`)
+in the UI.
+
 ---
 
 ## Safe Power Management (coordinator.py:1077-1193)
@@ -331,6 +376,15 @@ Fetches `energy_state` history from HA API (throttled 60s), shows what actually 
 | max_amperage_per_phase | number | 10-63 A | 16 | Grid current limit |
 | voltage_level | number | 48-60 V | 58 | Charge voltage setpoint |
 | discharge_min_voltage | number | 48-55 V | 50 | Discharge voltage floor |
+| charge_to_full_on_negative_price | select | off/on | off | Charge at every p<0 slot (revenue) |
+| discharge_to_make_room_for_negative_price | select | off/on | off | Pre-discharge before p<0 PV windows |
+
+All `HA_FelicityInternalNumber` configuration entities render as
+input boxes (`NumberMode.BOX`) so users can type precise values.
+Sliders are awkward for fractional / fine-grained settings like
+`efficiency_factor` (step 0.01) or `arbitrage_price_delta` (step
+0.01 €/kWh).  Pass `mode=NumberMode.SLIDER` to the constructor for
+entities that benefit from scrubbing.
 
 ### Key Sensor Entities
 

--- a/custom_components/ha_felicity/__init__.py
+++ b/custom_components/ha_felicity/__init__.py
@@ -191,6 +191,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "daily_consumption_estimate": 10,
         "price_mode": "manual",
         "safe_power_management": "auto",
+        "charge_to_full_on_negative_price": "off",
+        "discharge_to_make_room_for_negative_price": "off",
         CONF_REGISTER_SET: DEFAULT_REGISTER_SET,
         "update_interval": 10,
     }

--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -676,6 +676,12 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
             block_export_on_negative_price=opts.get(
                 "block_export_on_negative_price", True
             ),
+            charge_to_full_on_negative_price=opts.get(
+                "charge_to_full_on_negative_price", "off"
+            ) == "on",
+            discharge_to_make_room_for_negative_price=opts.get(
+                "discharge_to_make_room_for_negative_price", "off"
+            ) == "on",
         )
 
         state = ems_module.EMSState(

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -41,6 +41,17 @@ class EMSConfig:
     # (DE/NL) penalise feed-in at negative prices.  When True, sell slots
     # at p < 0 are blocked even in to_grid / both modes.
     block_export_on_negative_price: bool = True
+    # Negative-price strategies (orthogonal to grid_mode).
+    # charge_to_full_on_negative_price: extend charging beyond reserve
+    # target up to battery_charge_max during negative-price slots, even if
+    # PV alone wouldn't fill the battery.  Each grid-charged kWh is revenue
+    # (paid to consume); user accepts that some PV may need to be curtailed.
+    charge_to_full_on_negative_price: bool = False
+    # discharge_to_make_room_for_negative_price: schedule pre-emptive
+    # discharges before negative-price PV windows so the battery has room
+    # to absorb the PV (avoiding forced grid export at penalty rates).
+    # Discharge only happens in positive-price hours.
+    discharge_to_make_room_for_negative_price: bool = False
     # NOTE: battery State of Health (SOH) is applied by the coordinator
     # before constructing this config — it scales battery_capacity_kwh
     # by the SOH factor.  ems.py treats the capacity as already-effective.
@@ -459,6 +470,7 @@ def _validate_schedule_soc(
     inverter_max_power_kw: float = 0.0,
     safe_power_kw: float = 0.0,
     consumption_hourly_kwh: dict[int, float] | None = None,
+    keep_all_negative_charges: bool = False,
 ) -> tuple[set[int], set[int]]:
     """Validate schedule by simulating SOC at every slot, pruning violations.
 
@@ -466,6 +478,13 @@ def _validate_schedule_soc(
     battery_capacity] at every time slot.  If a discharge would cause SOC to
     dip below min, it is removed (least valuable first).  If a charge would
     push SOC above capacity, it is removed (most expensive first).
+
+    When keep_all_negative_charges is True, negative-price charge slots are
+    never pruned for overflow (except phantom-charge slots where the battery
+    is already at capacity entering the slot — those can't physically execute
+    regardless of price).  Used by the charge_to_full_on_negative_price
+    strategy: user has opted to charge during all negative slots, accepting
+    that some PV may be curtailed.
 
     Returns pruned (charge_slots, discharge_slots).
     """
@@ -560,6 +579,16 @@ def _validate_schedule_soc(
                 # hours that would otherwise be missed).
                 soc_no_charge = soc_before + (delta - charge_contribution)
                 pv_alone_overflows = soc_no_charge > battery_capacity + 0.01
+                slot_price = price_of.get(slot_idx, 0.0)
+                # User opted into charge_to_full_on_negative_price: treat
+                # phantom negative-price slots as harmless (the inverter
+                # may try to charge but BMS will gate it).  Skip phantom
+                # marking and just clamp soc, so the slot stays scheduled.
+                if (keep_all_negative_charges
+                        and charge_contribution > 0
+                        and slot_price < 0):
+                    soc = battery_capacity
+                    continue
                 if pv_alone_overflows:
                     # Phantom charge: action present on already-full battery.
                     # Drop regardless of price — the energy can't land.
@@ -633,6 +662,16 @@ def _validate_schedule_soc(
                         pv_surplus_total,
                     )
                     break
+                # User opted into charge_to_full_on_negative_price: keep
+                # negative-price slots even when PV alone wouldn't fill
+                # the battery.  Some PV may be curtailed but the user has
+                # explicitly chosen this trade-off (revenue at p<0 slots).
+                if keep_all_negative_charges and not violation_charge_wasted:
+                    _LOGGER.debug(
+                        "SOC validation: keeping negative-price charge slots "
+                        "(charge_to_full_on_negative_price=True)",
+                    )
+                    break
                 candidates = [
                     s for s in charge_slots
                     if s <= violation_slot
@@ -651,6 +690,159 @@ def _validate_schedule_soc(
             )
 
     return charge_slots, discharge_slots
+
+
+def _select_discharges_for_pv_headroom(
+    remaining: list[tuple[int, float]],
+    current_kwh: float,
+    scheduled_charge: set[int],
+    config: EMSConfig,
+    state: EMSState,
+    minutes_per_slot: float,
+    pv_confidence: float,
+    reserve_target: float,
+) -> set[int]:
+    """Pre-emptively discharge before negative-price PV windows.
+
+    Used by the discharge_to_make_room_for_negative_price strategy.  Walks
+    forward through remaining slots simulating SOC.  Whenever a negative-
+    price slot with PV surplus would overflow the battery, schedules
+    discharge in the most expensive positive-price earlier slots (which
+    aren't already charge slots) to create headroom.
+
+    Discharges may temporarily dip SOC below reserve_target during the
+    day (the negative-window PV will refill it), but must never violate
+    the absolute discharge_min floor, and end-of-day SOC after all
+    simulation must remain >= reserve_target so overnight is covered.
+
+    Returns set of slot indices to discharge.
+    """
+    discharge: set[int] = set()
+    if not state.pv_hourly_kwh or not remaining:
+        return discharge
+
+    max_battery_kwh = (config.battery_charge_max_pct / 100.0) * config.battery_capacity_kwh
+    min_kwh_floor = (config.battery_discharge_min_pct / 100.0) * config.battery_capacity_kwh
+    energy_per_slot = config.safe_power_kw * (minutes_per_slot / 60.0)
+    cons_per_slot_default = config.consumption_est_kwh / max(1, len(state.slot_prices_today or []))
+    if cons_per_slot_default <= 0:
+        cons_per_slot_default = config.consumption_est_kwh * (minutes_per_slot / 60.0) / 24.0
+
+    def _slot_cons(hour: int) -> float:
+        if state.consumption_hourly_kwh and hour in state.consumption_hourly_kwh:
+            return state.consumption_hourly_kwh[hour] * (minutes_per_slot / 60.0)
+        return cons_per_slot_default
+
+    def _slot_pv(hour: int) -> float:
+        return (state.pv_hourly_kwh or {}).get(hour, 0.0) * pv_confidence * (minutes_per_slot / 60.0)
+
+    def _project_soc(extra_discharge: set[int]) -> tuple[dict[int, float], float, float]:
+        """Project SOC entering each slot given current schedule + extra discharges.
+
+        Returns (per_slot_entering, soc_at_end, min_soc_observed).
+        """
+        soc = current_kwh
+        per_slot: dict[int, float] = {}
+        min_soc = soc
+        for idx, _ in remaining:
+            per_slot[idx] = soc
+            hour = int((idx * minutes_per_slot) / 60)
+            pv = _slot_pv(hour)
+            cons = _slot_cons(hour)
+            delta = pv - cons
+            if idx in scheduled_charge:
+                pv_kw_rate = (state.pv_hourly_kwh or {}).get(hour, 0.0) * pv_confidence
+                grid_kw = min(config.safe_power_kw,
+                              max(0.0, config.inverter_max_power_kw - pv_kw_rate))
+                delta += grid_kw * (minutes_per_slot / 60.0) * config.efficiency
+            if idx in (discharge | extra_discharge):
+                delta -= energy_per_slot
+            soc_raw = soc + delta  # before clamp — captures true dip
+            min_soc = min(min_soc, soc_raw)
+            soc = max(0.0, min(max_battery_kwh, soc_raw))
+        return per_slot, soc, min_soc
+
+    # Iterate (bounded) until no more overflow at negative+PV slots is reducible.
+    max_passes = len(remaining)
+    for _ in range(max_passes):
+        soc_in, _, _ = _project_soc(set())
+        # Find the FIRST negative-price slot with PV surplus that would overflow.
+        target_idx: int | None = None
+        for idx, price in remaining:
+            if price is None or price >= 0:
+                continue
+            hour = int((idx * minutes_per_slot) / 60)
+            pv = _slot_pv(hour)
+            cons = _slot_cons(hour)
+            if pv <= cons:
+                continue
+            # SOC at end of this slot if no discharge added
+            soc_end = soc_in[idx] + (pv - cons)
+            if idx in scheduled_charge:
+                pv_kw_rate = (state.pv_hourly_kwh or {}).get(hour, 0.0) * pv_confidence
+                grid_kw = min(config.safe_power_kw,
+                              max(0.0, config.inverter_max_power_kw - pv_kw_rate))
+                soc_end += grid_kw * (minutes_per_slot / 60.0) * config.efficiency
+            if soc_end > max_battery_kwh + 0.01:
+                target_idx = idx
+                break
+        if target_idx is None:
+            break
+
+        # Find earlier positive-price slots, not already charge/discharge, that
+        # we can discharge in.  Prefer the MOST expensive (highest revenue).
+        candidates = [
+            (idx, p) for idx, p in remaining
+            if idx < target_idx
+            and p is not None and p > 0
+            and idx not in scheduled_charge
+            and idx not in discharge
+        ]
+        if not candidates:
+            break
+        candidates.sort(key=lambda x: -x[1])  # most expensive first
+
+        added_this_pass = False
+        for cand_idx, _ in candidates:
+            # A discharge is acceptable when:
+            #  - SOC never drops below the absolute min_kwh floor at any
+            #    point in the simulation (hardware safety);
+            #  - end-of-day SOC remains >= reserve_target (overnight
+            #    self-consumption protection).
+            # Temporary dips below reserve_target during the day are OK
+            # because the negative-window PV refills the battery.
+            _, soc_end_day, soc_min_observed = _project_soc({cand_idx})
+            if soc_min_observed < min_kwh_floor - 0.01:
+                continue
+            if soc_end_day < reserve_target - 0.01:
+                continue
+            discharge.add(cand_idx)
+            added_this_pass = True
+            # Did this resolve the overflow at target_idx?
+            new_soc, _, _ = _project_soc(set())
+            hour = int((target_idx * minutes_per_slot) / 60)
+            pv = _slot_pv(hour)
+            cons = _slot_cons(hour)
+            soc_end = new_soc[target_idx] + (pv - cons)
+            if target_idx in scheduled_charge:
+                pv_kw_rate = (state.pv_hourly_kwh or {}).get(hour, 0.0) * pv_confidence
+                grid_kw = min(config.safe_power_kw,
+                              max(0.0, config.inverter_max_power_kw - pv_kw_rate))
+                soc_end += grid_kw * (minutes_per_slot / 60.0) * config.efficiency
+            if soc_end <= max_battery_kwh + 0.01:
+                break
+            # else: keep adding more discharge slots
+        if not added_this_pass:
+            break
+
+    if discharge:
+        _LOGGER.info(
+            "Make-room discharge: added %d slot(s) before negative-price PV "
+            "window(s): %s (current=%.1f kWh, max=%.1f kWh, reserve=%.1f kWh)",
+            len(discharge), sorted(discharge), current_kwh, max_battery_kwh,
+            reserve_target,
+        )
+    return discharge
 
 
 def select_unified_charge_slots(
@@ -1257,7 +1449,20 @@ def _schedule_from_grid(
     result.tomorrow_planned_slots = len(tomorrow_slots)
     result.tomorrow_planned_kwh = tomorrow_charge_kwh
 
-    if not selected:
+    # charge_to_full_on_negative_price: when any negative-price slot
+    # exists in the remaining window, ensure ALL of them get scheduled by
+    # adding them to the selection (deduplicated).  The user has opted to
+    # charge at every p<0 slot for the revenue, accepting potential PV
+    # curtailment.  SOC validation will keep these slots even if they'd
+    # otherwise overflow (see keep_all_negative_charges below).
+    if config.charge_to_full_on_negative_price:
+        selected_indices = {idx for idx, _ in selected}
+        for idx, price in remaining:
+            if price is not None and price < 0 and idx not in selected_indices:
+                selected.append((idx, price))
+                selected_indices.add(idx)
+
+    if not selected and not config.discharge_to_make_room_for_negative_price:
         result.status = "no_action_needed"
         return result
 
@@ -1272,15 +1477,29 @@ def _schedule_from_grid(
         consumption_hourly_kwh=state.consumption_hourly_kwh,
         inverter_max_power_kw=config.inverter_max_power_kw,
         safe_power_kw=config.safe_power_kw,
+        keep_all_negative_charges=config.charge_to_full_on_negative_price,
     )
     selected = [(idx, p) for idx, p in selected if idx in validated_charge]
 
-    if not selected:
+    # discharge_to_make_room_for_negative_price: in from_grid mode we
+    # normally don't discharge.  When this opt-in is enabled, schedule
+    # pre-emptive discharges before negative-price + PV windows so PV
+    # can fill the battery without forced grid export at penalty rates.
+    discharge_for_headroom: set[int] = set()
+    if config.discharge_to_make_room_for_negative_price:
+        discharge_for_headroom = _select_discharges_for_pv_headroom(
+            remaining, current_kwh, set(validated_charge),
+            config, state, minutes_per_slot, pv_confidence, reserve_target,
+        )
+
+    if not selected and not discharge_for_headroom:
         result.status = "no_action_needed"
         return result
 
     result.scheduled_slots = {s[0]: "charge" for s in selected}
-    result.cheap_slots_remaining = len(result.scheduled_slots)
+    for idx in discharge_for_headroom:
+        result.scheduled_slots[idx] = "discharge"
+    result.cheap_slots_remaining = len(selected)
     result.grid_energy_planned = round(len(selected) * effective_per_slot, 2)
 
     if selected:
@@ -1548,6 +1767,16 @@ def _schedule_both(
     sorted_expensive = sorted(available_for_sell, key=lambda x: -x[1])
     sell_selected = sorted_expensive[:sell_needed]
 
+    # charge_to_full_on_negative_price: ensure ALL negative-price slots
+    # are charged (in addition to the cheapest selection above).  Sell
+    # slots already exclude charge indices.
+    if config.charge_to_full_on_negative_price:
+        existing = {idx for idx, _ in charge_slots}
+        for idx, price in remaining:
+            if price is not None and price < 0 and idx not in existing:
+                charge_slots.append((idx, price))
+                existing.add(idx)
+
     # Per-slot SOC validation: ensure combined schedule respects battery bounds
     charge_set = {s[0] for s in charge_slots}
     discharge_set = {s[0] for s in sell_selected}
@@ -1560,15 +1789,33 @@ def _schedule_both(
         consumption_hourly_kwh=state.consumption_hourly_kwh,
         inverter_max_power_kw=config.inverter_max_power_kw,
         safe_power_kw=config.safe_power_kw,
+        keep_all_negative_charges=config.charge_to_full_on_negative_price,
     )
     charge_slots = [(idx, p) for idx, p in charge_slots if idx in validated_charge]
     sell_selected = [(idx, p) for idx, p in sell_selected if idx in validated_discharge]
+
+    # discharge_to_make_room_for_negative_price: add pre-emptive discharges
+    # before negative-price PV windows.  Both mode may already have sell
+    # slots — merge them; sell slots take precedence (higher revenue) when
+    # the same slot index would appear twice.
+    discharge_for_headroom: set[int] = set()
+    if config.discharge_to_make_room_for_negative_price:
+        existing_discharge = {idx for idx, _ in sell_selected}
+        existing_charge = {idx for idx, _ in charge_slots}
+        candidate = _select_discharges_for_pv_headroom(
+            remaining, current_kwh,
+            existing_charge,
+            config, state, minutes_per_slot, pv_confidence, reserve_target,
+        )
+        discharge_for_headroom = candidate - existing_discharge - existing_charge
 
     result.scheduled_slots = {}
     for s in charge_slots:
         result.scheduled_slots[s[0]] = "charge"
     for s in sell_selected:
         result.scheduled_slots[s[0]] = "discharge"
+    for idx in discharge_for_headroom:
+        result.scheduled_slots[idx] = "discharge"
 
     result.cheap_slots_remaining = len(charge_slots)
     charge_energy = round(len(charge_slots) * effective_per_slot, 2) if charge_slots else 0

--- a/custom_components/ha_felicity/number.py
+++ b/custom_components/ha_felicity/number.py
@@ -246,7 +246,13 @@ class HA_FelicityNumber(CoordinatorEntity, NumberEntity):
         self.async_write_ha_state()
 
 class HA_FelicityInternalNumber(CoordinatorEntity, NumberEntity):
-    """Generic internal number entity for user-configurable options (sliders)."""
+    """Generic internal number entity for user-configurable options.
+
+    Renders as an input box (NumberMode.BOX) so users can type precise
+    values — sliders are awkward for fractional / fine-grained settings
+    like efficiency factor or arbitrage price delta.  Sliders elsewhere
+    (Power Level, Price Threshold) keep the slider for quick scrubbing.
+    """
 
     def __init__(
         self,
@@ -261,6 +267,7 @@ class HA_FelicityInternalNumber(CoordinatorEntity, NumberEntity):
         icon: str | None = None,
         device_class: str | None = None,
         dynamic_range: bool = False,
+        mode: NumberMode = NumberMode.BOX,
     ):
         super().__init__(coordinator)
         self._entry = entry
@@ -272,10 +279,10 @@ class HA_FelicityInternalNumber(CoordinatorEntity, NumberEntity):
         self._attr_native_max_value = max_val
         self._attr_native_step = step
         self._dynamic_range = dynamic_range
-        
+
         if unit:
             self._attr_native_unit_of_measurement = unit
-        self._attr_mode = NumberMode.SLIDER
+        self._attr_mode = mode
         self._attr_entity_category = EntityCategory.CONFIG
 
         if icon:

--- a/custom_components/ha_felicity/select.py
+++ b/custom_components/ha_felicity/select.py
@@ -83,6 +83,30 @@ async def async_setup_entry(
         )
     )
 
+    entities.append(
+        HA_FelicitySpecialModeSelect(
+            coordinator=coordinator,
+            entry=entry,
+            option_key="charge_to_full_on_negative_price",
+            select_options=["off", "on"],
+            name="Charge to Full on Negative Price",
+            icon="mdi:battery-arrow-up",
+            entity_category=EntityCategory.CONFIG,
+        )
+    )
+
+    entities.append(
+        HA_FelicitySpecialModeSelect(
+            coordinator=coordinator,
+            entry=entry,
+            option_key="discharge_to_make_room_for_negative_price",
+            select_options=["off", "on"],
+            name="Discharge to Make Room for Negative Price",
+            icon="mdi:battery-arrow-down",
+            entity_category=EntityCategory.CONFIG,
+        )
+    )
+
     # Tie all entities to the device
     for entity in entities:
         entity._attr_device_info = device_info

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -3562,3 +3562,349 @@ class TestTomorrowFullBatteryNoPhantomCharge:
             f"With headroom, all negative-price slots should still charge: "
             f"got {len(neg_charged)} of {len(neg_slots)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test: Negative-price strategies (charge_to_full / discharge_to_make_room)
+# ---------------------------------------------------------------------------
+
+class TestChargeToFullOnNegativePrice:
+    """charge_to_full_on_negative_price: schedule every p<0 slot, even if
+    SOC validation would otherwise prune it because PV alone wouldn't fill
+    the battery (i.e., accepting forced PV curtailment / export risk)."""
+
+    def _prices_with_negatives(self, n_slots: int = 24) -> list[float]:
+        # 0..6 mild positive, 7..9 deeply negative, 10..23 positive ramp.
+        p = [0.10] * n_slots
+        for i in (7, 8, 9):
+            p[i] = -0.20
+        for i in range(10, n_slots):
+            p[i] = 0.05 + 0.01 * (i - 10)
+        return p
+
+    def test_negative_slots_kept_with_flag(self):
+        """With the flag ON, all negative slots are scheduled even when
+        the battery starts near full and PV alone wouldn't fill it."""
+        prices = self._prices_with_negatives(24)
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10.0,
+            battery_charge_max_pct=100.0,
+            battery_discharge_min_pct=20.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=5.0,
+            consumption_est_kwh=10.0,
+            charge_to_full_on_negative_price=True,
+        )
+        state = default_state(
+            battery_soc_pct=85.0,  # nearly full — would normally prune negs
+            slot_prices_today=prices,
+            pv_hourly_kwh={},  # no PV
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=0.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=6,
+        )
+        result = calculate_schedule(config, state)
+        neg_slots = {i for i, p in enumerate(prices) if p < 0 and i >= 6}
+        charges = {k for k, v in result.scheduled_slots.items() if v == "charge"}
+        assert neg_slots.issubset(charges), (
+            f"All negative slots {sorted(neg_slots)} should be charged with "
+            f"the flag on; got {sorted(charges)}"
+        )
+
+    def test_negative_slots_pruned_without_flag(self):
+        """Baseline: without the flag and no PV-fills-battery exemption,
+        negative-price slots that would overflow are pruned."""
+        prices = self._prices_with_negatives(24)
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10.0,
+            battery_charge_max_pct=100.0,
+            battery_discharge_min_pct=20.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=5.0,
+            consumption_est_kwh=10.0,
+            charge_to_full_on_negative_price=False,
+        )
+        state = default_state(
+            battery_soc_pct=95.0,  # essentially full
+            slot_prices_today=prices,
+            pv_hourly_kwh={},
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=0.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=6,
+        )
+        result = calculate_schedule(config, state)
+        neg_slots = {i for i, p in enumerate(prices) if p < 0 and i >= 6}
+        charges = {k for k, v in result.scheduled_slots.items() if v == "charge"}
+        # Without the flag, the battery is too full — most negative slots get pruned
+        assert len(charges & neg_slots) < len(neg_slots), (
+            f"Without flag, near-full battery should prune some negative slots; "
+            f"got all {len(charges & neg_slots)}/{len(neg_slots)} kept"
+        )
+
+    def test_flag_in_both_mode(self):
+        """The flag applies to both mode as well — all negatives kept."""
+        prices = self._prices_with_negatives(24)
+        config = default_config(
+            grid_mode="both",
+            battery_capacity_kwh=10.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=5.0,
+            charge_to_full_on_negative_price=True,
+        )
+        state = default_state(
+            battery_soc_pct=85.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh={},
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=0.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=6,
+        )
+        result = calculate_schedule(config, state)
+        neg_slots = {i for i, p in enumerate(prices) if p < 0 and i >= 6}
+        charges = {k for k, v in result.scheduled_slots.items() if v == "charge"}
+        assert neg_slots.issubset(charges)
+
+    def test_flag_off_keeps_legacy_behavior(self):
+        """With flag OFF, existing PV-fills-battery exemption still applies."""
+        prices = self._prices_with_negatives(24)
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=60.0,
+            charge_to_full_on_negative_price=False,
+        )
+        # Large PV that will fill the battery — exemption keeps neg slots.
+        state = default_state(
+            battery_soc_pct=80.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=make_pv_hourly(40.0),
+            pv_forecast_remaining=25.0,
+            pv_forecast_today=40.0,
+            pv_actual_today_kwh=15.0,
+            current_hour=6,
+        )
+        result = calculate_schedule(config, state)
+        neg_slots = {i for i, p in enumerate(prices) if p < 0 and i >= 6}
+        charges = {k for k, v in result.scheduled_slots.items() if v == "charge"}
+        # PV-fills-battery exemption should keep most negatives
+        assert len(charges & neg_slots) >= 1
+
+
+class TestDischargeToMakeRoomForNegativePrice:
+    """discharge_to_make_room_for_negative_price: pre-emptively discharge
+    in earlier positive-price slots so the battery has headroom to absorb
+    PV during negative-price windows (avoiding forced grid export at
+    penalty rates)."""
+
+    def test_no_discharge_without_flag(self):
+        """Baseline: with flag OFF, from_grid mode never schedules discharge."""
+        # PV mostly during a negative-price window; battery starts near full.
+        prices = [0.20] * 11 + [-0.10] * 4 + [0.20] * 9  # negatives at 11-14
+        # PV concentrated at hours 11-14 (negative window).
+        pv_hourly = {11: 8.0, 12: 8.0, 13: 8.0, 14: 8.0}
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10.0,
+            battery_charge_max_pct=100.0,
+            battery_discharge_min_pct=20.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+            consumption_est_kwh=4.0,
+            discharge_to_make_room_for_negative_price=False,
+        )
+        state = default_state(
+            battery_soc_pct=90.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=pv_hourly,
+            pv_forecast_remaining=32.0,
+            pv_forecast_today=32.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=7,
+        )
+        result = calculate_schedule(config, state)
+        discharges = [k for k, v in result.scheduled_slots.items() if v == "discharge"]
+        assert discharges == [], (
+            f"from_grid mode without flag should never discharge; got {discharges}"
+        )
+
+    def test_discharge_scheduled_with_flag(self):
+        """With flag ON, discharge slots appear before negative-price PV window."""
+        prices = [0.20] * 11 + [-0.10] * 4 + [0.20] * 9  # negatives at 11-14
+        pv_hourly = {11: 8.0, 12: 8.0, 13: 8.0, 14: 8.0}
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10.0,
+            battery_charge_max_pct=100.0,
+            battery_discharge_min_pct=20.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+            consumption_est_kwh=4.0,
+            discharge_to_make_room_for_negative_price=True,
+        )
+        state = default_state(
+            battery_soc_pct=90.0,  # near full — needs to make room
+            slot_prices_today=prices,
+            pv_hourly_kwh=pv_hourly,
+            pv_forecast_remaining=32.0,
+            pv_forecast_today=32.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=7,
+        )
+        result = calculate_schedule(config, state)
+        discharges = [k for k, v in result.scheduled_slots.items() if v == "discharge"]
+        assert len(discharges) > 0, (
+            "Expected at least one pre-emptive discharge slot when battery "
+            "is near-full and a negative-price PV window is coming"
+        )
+        # All discharges should be in positive-price slots BEFORE the negative window
+        first_neg = 11
+        for d in discharges:
+            assert d < first_neg, f"discharge {d} should be before neg window at {first_neg}"
+            assert prices[d] > 0, f"discharge {d} should be at positive price, got {prices[d]}"
+
+    def test_no_discharge_when_battery_has_room(self):
+        """When battery has plenty of headroom, no pre-emptive discharge needed."""
+        prices = [0.20] * 11 + [-0.10] * 4 + [0.20] * 9
+        pv_hourly = {11: 8.0, 12: 8.0, 13: 8.0, 14: 8.0}
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=30.0,
+            battery_charge_max_pct=100.0,
+            battery_discharge_min_pct=20.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+            consumption_est_kwh=10.0,
+            discharge_to_make_room_for_negative_price=True,
+        )
+        state = default_state(
+            battery_soc_pct=30.0,  # plenty of headroom
+            slot_prices_today=prices,
+            pv_hourly_kwh=pv_hourly,
+            pv_forecast_remaining=32.0,
+            pv_forecast_today=32.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=7,
+        )
+        result = calculate_schedule(config, state)
+        discharges = [k for k, v in result.scheduled_slots.items() if v == "discharge"]
+        # Battery can fully absorb the PV — no make-room needed
+        assert discharges == [], (
+            f"No discharge needed when battery has headroom; got {discharges}"
+        )
+
+    def test_no_discharge_without_pv(self):
+        """No PV during negative window = no overflow risk = no discharge."""
+        prices = [0.20] * 11 + [-0.10] * 4 + [0.20] * 9
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10.0,
+            discharge_to_make_room_for_negative_price=True,
+        )
+        state = default_state(
+            battery_soc_pct=90.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh={},  # no PV
+            pv_forecast_remaining=0.0,
+            pv_forecast_today=0.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=7,
+        )
+        result = calculate_schedule(config, state)
+        discharges = [k for k, v in result.scheduled_slots.items() if v == "discharge"]
+        assert discharges == [], (
+            f"No PV = no overflow risk = no pre-emptive discharge; got {discharges}"
+        )
+
+    def test_respects_reserve_target(self):
+        """Pre-emptive discharge must not push SOC below reserve target."""
+        prices = [0.20] * 11 + [-0.10] * 4 + [0.20] * 9
+        pv_hourly = {11: 8.0, 12: 8.0, 13: 8.0, 14: 8.0}
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10.0,
+            battery_charge_max_pct=100.0,
+            battery_discharge_min_pct=20.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+            consumption_est_kwh=4.0,
+            reserve_target_pct=60.0,  # high reserve floor
+            discharge_to_make_room_for_negative_price=True,
+        )
+        state = default_state(
+            battery_soc_pct=70.0,  # just above reserve
+            slot_prices_today=prices,
+            pv_hourly_kwh=pv_hourly,
+            pv_forecast_remaining=32.0,
+            pv_forecast_today=32.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=7,
+        )
+        result = calculate_schedule(config, state)
+        # Walk SOC forward and check reserve is never violated by pre-emptive discharge
+        soc_kwh = (state.battery_soc_pct / 100.0) * config.battery_capacity_kwh
+        reserve_kwh = (config.reserve_target_pct / 100.0) * config.battery_capacity_kwh
+        energy_per_slot = config.safe_power_kw  # 1h slots
+        num_slots = len(prices)
+        for i in range(state.current_hour, num_slots):
+            pv = pv_hourly.get(i, 0.0)
+            cons = config.consumption_est_kwh / num_slots
+            delta = pv - cons
+            action = result.scheduled_slots.get(i)
+            if action == "discharge":
+                delta -= energy_per_slot
+                # Must not push SOC below reserve at any time during/after discharge
+                assert (soc_kwh + delta) >= reserve_kwh - 0.05, (
+                    f"Pre-emptive discharge at slot {i} would push SOC below "
+                    f"reserve {reserve_kwh:.2f} (would reach {soc_kwh + delta:.2f})"
+                )
+            soc_kwh = max(0.0, min(config.battery_capacity_kwh, soc_kwh + delta))
+
+
+class TestNegativePriceStrategiesComposable:
+    """Both flags can be enabled together — they don't conflict."""
+
+    def test_both_flags_together(self):
+        """charge_to_full + discharge_to_make_room work together: discharge
+        before the window creates space, then we charge at the negatives."""
+        # 24 slots. Negatives at 11-14, PV during 10-15, battery near full.
+        prices = [0.20] * 11 + [-0.10] * 4 + [0.20] * 9
+        pv_hourly = {10: 6.0, 11: 8.0, 12: 8.0, 13: 8.0, 14: 8.0, 15: 6.0}
+        config = default_config(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10.0,
+            battery_charge_max_pct=100.0,
+            battery_discharge_min_pct=20.0,
+            safe_power_kw=5.0,
+            inverter_max_power_kw=10.0,
+            consumption_est_kwh=4.0,
+            charge_to_full_on_negative_price=True,
+            discharge_to_make_room_for_negative_price=True,
+        )
+        state = default_state(
+            battery_soc_pct=90.0,
+            slot_prices_today=prices,
+            pv_hourly_kwh=pv_hourly,
+            pv_forecast_remaining=44.0,
+            pv_forecast_today=44.0,
+            pv_actual_today_kwh=0.0,
+            current_hour=7,
+        )
+        result = calculate_schedule(config, state)
+        charges = {k for k, v in result.scheduled_slots.items() if v == "charge"}
+        discharges = {k for k, v in result.scheduled_slots.items() if v == "discharge"}
+        neg_slots = {i for i, p in enumerate(prices) if p < 0 and i >= 7}
+        # All negatives scheduled as charge (charge_to_full)
+        assert neg_slots.issubset(charges), (
+            f"Both flags on: all neg slots {sorted(neg_slots)} should be charged; "
+            f"got {sorted(charges)}"
+        )
+        # Some discharge before the negative window (make_room)
+        early_discharges = {d for d in discharges if d < 11}
+        assert early_discharges, (
+            "Both flags on: expected pre-emptive discharges before the "
+            "negative window; got none"
+        )


### PR DESCRIPTION
Two new orthogonal EMS config flags (off by default, compose with all grid modes):

- charge_to_full_on_negative_price: schedule every p<0 slot even when SOC validation would otherwise prune it (user accepts forced PV curtailment in exchange for guaranteed revenue at p<0).
- discharge_to_make_room_for_negative_price: pre-emptively discharge in earlier positive-price slots so the battery has headroom to absorb PV during p<0 windows (avoiding forced grid export at penalty rates).  Works in from_grid mode too, which normally never discharges.

Both flags compose: pre-discharge clears space, then charge_to_full fills the battery from grid at p<0.  Exposed as off/on select entities in the HA UI.

Also: HA_FelicityInternalNumber defaults to NumberMode.BOX so users can type precise values for fractional / fine-grained settings (efficiency_factor, arbitrage_price_delta, reserve_target_pct, etc.). Sliders were hard to read and set precisely.  Pass mode=SLIDER explicitly to opt back in.

10 new ems tests cover the strategies in from_grid, both, and composed forms.  All 158 ems tests pass.