### PR TITLE
Include daily load register in basic set for all models

### DIFF
--- a/custom_components/ha_felicity/trex_fifty.py
+++ b/custom_components/ha_felicity/trex_fifty.py
@@ -690,7 +690,8 @@ REGISTER_SETS_TREX_FIFTY = {
             "inverter_time", "econ_rule_1", "econ_rule_2", "econ_rule_3",
             "econ_rule_4", "econ_rule_5", "econ_rule_6", "alarm_codes", "fault_codes",
             "phase_a_home_load_power", "phase_b_home_load_power", "phase_c_home_load_power",
-            "generator_frequency", "grid_frequency", "load_frequency"
+            "generator_frequency", "grid_frequency", "load_frequency",
+            "homeload_day_cost_energy",
         }
     },
     "basic_plus": {

--- a/custom_components/ha_felicity/trex_five.py
+++ b/custom_components/ha_felicity/trex_five.py
@@ -488,6 +488,7 @@ REGISTER_SETS_TREX_FIVE = {
             "pv_generated_energy_year",
             "battery_charged_energy_day",
             "battery_discharged_energy_day",
+            "load_consumption_energy_day",
         }
         and "_secondary" not in key  # ← Excludes duplicates!
     },

--- a/custom_components/ha_felicity/trex_ten.py
+++ b/custom_components/ha_felicity/trex_ten.py
@@ -503,6 +503,7 @@ REGISTER_SETS_TREX_TEN = {
             "pv_generated_energy_year",
             "battery_charged_energy_day",
             "battery_discharged_energy_day",
+            "load_consumption_energy_day",
         }
         and "_secondary" not in key  # ← Excludes duplicates!
     },

--- a/custom_components/ha_felicity/trex_twenty_five.py
+++ b/custom_components/ha_felicity/trex_twenty_five.py
@@ -690,7 +690,8 @@ REGISTER_SETS_TREX_TWENTY_FIVE = {
             "inverter_time", "econ_rule_1", "econ_rule_2", "econ_rule_3",
             "econ_rule_4", "econ_rule_5", "econ_rule_6", "alarm_codes", "fault_codes",
             "phase_a_home_load_power", "phase_b_home_load_power", "phase_c_home_load_power",
-            "generator_frequency", "grid_frequency", "load_frequency"
+            "generator_frequency", "grid_frequency", "load_frequency",
+            "homeload_day_cost_energy",
         }
     },
     "basic_plus": {


### PR DESCRIPTION
The coordinator's _record_daily_consumption probes a list of load/consumption keys to compute the 7-day rolling average.  None of them were present in the basic register set, so basic-set users got a 'No daily consumption data found' warning every midnight and the weekly_avg fallback never populated.

Added:
- TREX-5/10: load_consumption_energy_day (address 4456)
- TREX-25/50: homeload_day_cost_energy (address 4596)

One extra register per cycle on basic; insignificant overhead.