### PR TITLE
Include PV + gen-port energy registers in basic set for TREX-25/50

### DIFF
--- a/custom_components/ha_felicity/trex_fifty.py
+++ b/custom_components/ha_felicity/trex_fifty.py
@@ -692,6 +692,8 @@ REGISTER_SETS_TREX_FIFTY = {
             "phase_a_home_load_power", "phase_b_home_load_power", "phase_c_home_load_power",
             "generator_frequency", "grid_frequency", "load_frequency",
             "homeload_day_cost_energy",
+            "pv1_day_energy", "pv2_day_energy", "pv3_day_energy", "pv4_day_energy",
+            "generator_day_cost_energy", "microinverter_day_cost_energy",
         }
     },
     "basic_plus": {

--- a/custom_components/ha_felicity/trex_twenty_five.py
+++ b/custom_components/ha_felicity/trex_twenty_five.py
@@ -692,6 +692,8 @@ REGISTER_SETS_TREX_TWENTY_FIVE = {
             "phase_a_home_load_power", "phase_b_home_load_power", "phase_c_home_load_power",
             "generator_frequency", "grid_frequency", "load_frequency",
             "homeload_day_cost_energy",
+            "pv1_day_energy", "pv2_day_energy", "pv3_day_energy", "pv4_day_energy",
+            "generator_day_cost_energy", "microinverter_day_cost_energy",
         }
     },
     "basic_plus": {


### PR DESCRIPTION
The coordinator's pv_actual_today_kwh property has a fallback chain: sum pv1-4_day_energy, else fall back to generator_day_cost_energy / microinverter_day_cost_energy for installations where PV is connected via the generator port (micro-inverters).  None of these registers were in the basic register set for TREX-25/50, so:

- Users with normal PV input on basic saw PV Today = 0
- Users with gen-port PV on basic saw PV Today = 0 (fallback couldn't trigger because the fallback registers weren't being read)

When pv_actual_today_kwh is 0 but pv_forecast_today is non-zero, the PV confidence factor drops aggressively → EMS perceives a deficit that doesn't exist → over-aggressive grid charging in mid-priced slots later in the day (because cheap morning slots already passed under the optimistic forecast).

Added to basic for TREX-25/50:
- pv1_day_energy, pv2_day_energy, pv3_day_energy, pv4_day_energy (per-string PV daily energy)
- generator_day_cost_energy, microinverter_day_cost_energy (gen-port fallback for micro-inverter solar installations)

Six extra single-register reads per cycle.  The fallback logic in coordinator.pv_actual_today_kwh already handles selection — this just makes the data available.