### PR TITLE
Use real hourly PV data for tomorrow preview, widen fallback to 05-21h

### DIFF
--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -91,6 +91,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self.pv_forecast_remaining: float | None = None
         self.pv_forecast_tomorrow: float | None = None
         self.pv_hourly_kwh: dict[int, float] = {}  # {hour: kwh} from forecast entity
+        self.pv_hourly_kwh_tomorrow: dict[int, float] = {}  # tomorrow's hourly PV
         self.scheduled_slots: dict[int, str] = {}  # {slot_idx: "charge" | "discharge"}
         self.slot_overrides: dict = config_entry.options.get("slot_overrides", {})  # manual overrides from card, persisted in entry.options
         self.cheap_slots_remaining: int = 0
@@ -495,9 +496,11 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
 
         now = datetime.now()
         today_date = now.date()
+        tomorrow_date = today_date + timedelta(days=1)
         attrs = state.attributes or {}
         remaining = None
         hourly_kwh: dict[int, float] = {}
+        hourly_kwh_tomorrow: dict[int, float] = {}
 
         # Try Forecast.Solar (wh_hours) or Solcast (detailedHourly) hourly breakdown
         wh_data = attrs.get("wh_hours") or attrs.get("detailedHourly")
@@ -508,11 +511,10 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
                     ts = self._parse_forecast_time(ts_str)
                     if ts:
                         wh_val = float(value)
-                        # Only accumulate entries for today — otherwise a
-                        # multi-day forecast pollutes the hour buckets with
-                        # tomorrow's/day-after's values (same hour, different day).
                         if ts.date() == today_date:
                             hourly_kwh[ts.hour] = hourly_kwh.get(ts.hour, 0.0) + wh_val / 1000.0
+                        elif ts.date() == tomorrow_date:
+                            hourly_kwh_tomorrow[ts.hour] = hourly_kwh_tomorrow.get(ts.hour, 0.0) + wh_val / 1000.0
                         if ts >= now:
                             remaining_wh += wh_val
                 remaining = remaining_wh / 1000.0
@@ -520,6 +522,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("Could not parse forecast hourly data: %s", err)
 
         self.pv_hourly_kwh = hourly_kwh
+        self.pv_hourly_kwh_tomorrow = hourly_kwh_tomorrow
 
         # Derive today's total from the (date-filtered) hourly data.  This
         # recovers the correct forecast when the entity's state attribute is

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -560,11 +560,18 @@ class FelicityEMSCard extends LitElement {
     if (tomorrowPvOnly) {
       const numSlotsToday = todaySlotData?.length || 24;
       tomorrowSlotData = [];
-      const daylightHours = 12;
-      const pvPerDaylightSlot = pvTomorrowKwh / (daylightHours * (numSlotsToday / 24));
+      const pvHourlyTmr = sim.pv_hourly_kwh_tomorrow || {};
+      const hasHourlyData = Object.keys(pvHourlyTmr).length > 0;
+      const slotsPerHour = numSlotsToday / 24;
       for (let i = 0; i < numSlotsToday; i++) {
-        const hour = (i * granularity) / 60;
-        const pvKwh = (hour >= 6 && hour < 18) ? pvPerDaylightSlot : 0;
+        const hour = Math.floor((i * granularity) / 60);
+        let pvKwh = 0;
+        if (hasHourlyData) {
+          pvKwh = (pvHourlyTmr[hour] ?? pvHourlyTmr[String(hour)] ?? 0) / slotsPerHour;
+        } else {
+          // Fallback: distribute evenly across 05–21 (summer-safe)
+          if (hour >= 5 && hour < 21) pvKwh = pvTomorrowKwh / (16 * slotsPerHour);
+        }
         tomorrowSlotData.push({ slot: i, price: null, action: null, pvKwh });
       }
     }
@@ -793,7 +800,7 @@ class FelicityEMSCard extends LitElement {
         const pvVal = slot.pvKwh || 0;
         barH = (pvVal / pvBarMax) * chartH;
         y = marginTop + chartH - barH;
-        ctx.fillStyle = pvVal > 0 ? "rgba(255, 213, 79, 0.7)" : "rgba(100, 140, 200, 0.15)";
+        ctx.fillStyle = pvVal > 0 ? "rgba(255, 223, 120, 0.55)" : "rgba(100, 140, 200, 0.15)";
         ctx.fillRect(x + 0.5, y, Math.max(1, barW - 1), barH);
         continue;
       }
@@ -1016,7 +1023,7 @@ class FelicityEMSCard extends LitElement {
 
     // PV-only banner: inform user this is a solar-only preview
     if (isPvOnlyView) {
-      ctx.fillStyle = "rgba(255, 213, 79, 0.9)";
+      ctx.fillStyle = "rgba(255, 223, 120, 0.9)";
       ctx.font = "bold 11px sans-serif";
       ctx.textAlign = "center";
       ctx.fillText("Without grid actions · Prices expected ~13:00", w / 2, marginTop + 14);
@@ -1083,7 +1090,7 @@ class FelicityEMSCard extends LitElement {
     if (isPvOnlyView) {
       // PV forecast legend
       lx -= 55;
-      ctx.fillStyle = "rgba(255, 213, 79, 0.7)";
+      ctx.fillStyle = "rgba(255, 223, 120, 0.55)";
       ctx.fillRect(lx - 55, 2, 8, 8);
       ctx.fillStyle = textColor;
       ctx.fillText("solar", lx - 58 + 32, 9);
@@ -1272,12 +1279,13 @@ class FelicityEMSCard extends LitElement {
         // that would push SOC below reserve_target. Matches backend
         // _validate_schedule_soc behavior.
         const consumptionProfile = sim.consumption_hourly_profile || null;
-        const pvHourlyTmr = null; // TODO: tomorrow hourly PV not available yet
+        const pvHourlyTmr = sim.pv_hourly_kwh_tomorrow || null;
+        const hasHourlyTmr = pvHourlyTmr && Object.keys(pvHourlyTmr).length > 0;
         const pvFallbackTotal = pvTomorrow;
         const daylightSlots = [];
         for (let ii = 0; ii < numSlots; ii++) {
-          const hr = (ii * granularity) / 60;
-          if (hr >= 6 && hr < 18) daylightSlots.push(ii);
+          const hr = Math.floor((ii * granularity) / 60);
+          if (hr >= 5 && hr < 21) daylightSlots.push(ii);
         }
         const pvPerDaylightSlot = daylightSlots.length > 0 ? pvFallbackTotal / daylightSlots.length : 0;
         const daylightSet = new Set(daylightSlots);
@@ -1294,7 +1302,9 @@ class FelicityEMSCard extends LitElement {
             const cons = consumptionProfile
               ? ((consumptionProfile[hr] ?? consumptionProfile[String(hr)] ?? (consumption / 24)) * slotDuration)
               : (consumption / 24) * slotDuration;
-            const pv = daylightSet.has(ii) ? pvPerDaylightSlot : 0;
+            const pv = hasHourlyTmr
+              ? ((pvHourlyTmr[hr] ?? pvHourlyTmr[String(hr)] ?? 0) * slotDuration)
+              : (daylightSet.has(ii) ? pvPerDaylightSlot : 0);
             const pvKwRate = slotDuration > 0 ? pv / slotDuration : 0;
             let delta = pv - cons;
             if (chargeSet.has(ii)) {
@@ -1373,9 +1383,11 @@ class FelicityEMSCard extends LitElement {
     // PV production per slot — use per-hour data when available (matches backend)
     // Apply pv_confidence from backend to scale forecast on cloudy days
     const pvConfidence = (!showTomorrow && sim.pv_confidence != null) ? sim.pv_confidence : 1.0;
-    const pvHourlyRaw = (!showTomorrow && sim.pv_hourly_kwh) ? sim.pv_hourly_kwh : null;
+    const pvHourlyRaw = showTomorrow
+      ? (sim.pv_hourly_kwh_tomorrow || null)
+      : (sim.pv_hourly_kwh || null);
     const pvHourly = (pvHourlyRaw && Object.keys(pvHourlyRaw).length > 0) ? pvHourlyRaw : null;
-    // Fallback for tomorrow or when hourly data unavailable: distribute total across 6–18
+    // Fallback when hourly data unavailable: distribute total across 05–21
     let pvFallbackPerSlot = 0;
     const pvFallbackSlotSet = new Set();
     if (!pvHourly) {
@@ -1384,8 +1396,8 @@ class FelicityEMSCard extends LitElement {
         : (this._getNumericState("pv_forecast_remaining") || 0);
       const daylightSlots = [];
       for (let i = 0; i < numSlots; i++) {
-        const hour = (i * granularity) / 60;
-        if (hour >= 6 && hour < 18) daylightSlots.push(i);
+        const hour = Math.floor((i * granularity) / 60);
+        if (hour >= 5 && hour < 21) daylightSlots.push(i);
       }
       pvFallbackPerSlot = daylightSlots.length > 0 ? pvTotal / daylightSlots.length : 0;
       daylightSlots.forEach(s => pvFallbackSlotSet.add(s));

--- a/custom_components/ha_felicity/sensor.py
+++ b/custom_components/ha_felicity/sensor.py
@@ -184,6 +184,7 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
                 "net_pv_kwh": getattr(self.coordinator, '_last_net_pv', 0),
                 "consumption_est_kwh": self.coordinator._get_consumption_estimate(),
                 "pv_hourly_kwh": self.coordinator.pv_hourly_kwh or {},
+                "pv_hourly_kwh_tomorrow": self.coordinator.pv_hourly_kwh_tomorrow or {},
                 "pv_confidence": getattr(self.coordinator, '_last_pv_confidence', 1.0),
                 "consumption_hourly_profile": self.coordinator._hourly_consumption_profile or {},
                 "backend_soc_trajectory": self.coordinator._backend_soc_trajectory,


### PR DESCRIPTION
- Extract tomorrow's hourly PV breakdown from wh_hours forecast data and pass it via sim_params.pv_hourly_kwh_tomorrow to the frontend
- PV-only preview now shows the actual solar curve shape instead of flat bars across a hardcoded 06-18 window
- Fallback (no hourly data) widened from 06-18 to 05-21 for northern latitude summer compatibility
- Soften PV bar color from saturated amber to lighter warm-yellow

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF