### PR TITLE
Fix chart crash: sim not defined in PV-only preview block

### DIFF
--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -560,7 +560,8 @@ class FelicityEMSCard extends LitElement {
     if (tomorrowPvOnly) {
       const numSlotsToday = todaySlotData?.length || 24;
       tomorrowSlotData = [];
-      const pvHourlyTmr = sim.pv_hourly_kwh_tomorrow || {};
+      const simEarly = this._getAttr("schedule_status", "sim_params") || {};
+      const pvHourlyTmr = simEarly.pv_hourly_kwh_tomorrow || {};
       const hasHourlyData = Object.keys(pvHourlyTmr).length > 0;
       const slotsPerHour = numSlotsToday / 24;
       for (let i = 0; i < numSlotsToday; i++) {


### PR DESCRIPTION
The PV-only preview code referenced 'sim' (sim_params) before it was declared in _drawSlotTimeline, causing ReferenceError that broke the entire chart rendering — not just the tomorrow tab.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF