### PR TITLE
Add Flexible Loads panel to EMS card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,8 +542,20 @@ select.select_option).
 - Cyan strip at bottom of bars where loads are scheduled
 - "loads" entry in legend (only when loads configured)
 - "N/M loads active" stat in the stats row
+- **Flexible Loads panel** (`_renderFlexLoads`, below the stats row, only
+  when loads configured): one row per load showing on/off state (dim when
+  off, cyan glow when on), the live power draw with a fill bar
+  (`active_power_kw / max_power_kw`), the EV charger's active current
+  detail (`A · φ · V`), a `BOOST` chip during EV boost, and a colour-coded
+  shed-priority badge ("Sheds 1st/2nd/last").  Header shows total live kW.
+  Footer reminds that loads are shed before the battery power is reduced.
 - `flex_load_schedule`, `flex_load_states`, `flex_load_configs` in
-  `schedule_status` attributes
+  `schedule_status` attributes.  `flex_load_configs` entries carry
+  `on`, `active_power_kw`, `max_power_kw`, `priority`, and (EV only)
+  `current_a`, `phases`, `voltage` — built by
+  `HA_FelicityScheduleStatusSensor._build_flex_load_attr`.  EV
+  `active_power_kw` is the *real* draw (`current_step × voltage × phases`),
+  falling back to the startup current when no step has been set yet.
 
 ### EV Boost Override
 

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -1952,6 +1952,8 @@ class FelicityEMSCard extends LitElement {
             ` : ""}
           </div>
 
+          ${this._renderFlexLoads(flexLoadConfigs)}
+
           <!-- PV Actual & Forecast -->
           <div class="pv-row">
             <div class="pv-item">
@@ -2192,6 +2194,64 @@ class FelicityEMSCard extends LitElement {
     `;
   }
 
+  // Flexible-loads panel: per-load on/off, live power draw, and the order
+  // in which loads are shed when grid current gets too high.
+  _renderFlexLoads(configs) {
+    if (!configs || configs.length === 0) return html``;
+    const evBoost = this._getAttr("schedule_status", "ev_boost_active") || false;
+    const totalActive = configs.reduce((a, c) => a + (c.active_power_kw || 0), 0);
+    const anyOn = configs.some((c) => c.on);
+
+    // priority 3 = least important (shed first); 1 = most important (shed last)
+    const prioInfo = (p) => {
+      if (p >= 3) return { label: "Sheds 1st", cls: "prio-first" };
+      if (p === 2) return { label: "Sheds 2nd", cls: "prio-mid" };
+      return { label: "Sheds last", cls: "prio-last" };
+    };
+
+    return html`
+      <div class="loads-panel">
+        <div class="loads-panel-head">
+          <span class="loads-title">
+            <ha-icon icon="mdi:power-plug"></ha-icon> Flexible Loads
+          </span>
+          <span class="loads-total ${anyOn ? 'on' : ''}">${this._fmt(totalActive, 1)} kW now</span>
+        </div>
+        <div class="loads-list">
+          ${configs.map((c) => {
+            const max = c.max_power_kw > 0 ? c.max_power_kw : (c.active_power_kw || 1);
+            const fillPct = c.on ? Math.max(6, Math.min(100, (c.active_power_kw / max) * 100)) : 0;
+            const pi = prioInfo(c.priority);
+            const isEvBoost = c.is_ev && evBoost;
+            return html`
+              <div class="load-row ${c.on ? 'active' : ''}">
+                <ha-icon class="load-glyph"
+                  icon="${c.is_ev ? 'mdi:ev-station' : 'mdi:power-plug-outline'}"></ha-icon>
+                <div class="load-main">
+                  <div class="load-line">
+                    <span class="load-name">${c.name}</span>
+                    ${isEvBoost ? html`<span class="load-boost">BOOST</span>` : ''}
+                    <span class="load-power">${c.on ? `${this._fmt(c.active_power_kw, 1)} kW` : 'off'}</span>
+                  </div>
+                  <div class="load-bar"><div class="load-bar-fill" style="width:${fillPct}%"></div></div>
+                  ${c.is_ev && c.on && c.current_a != null ? html`
+                    <div class="load-sub">${c.current_a} A · ${c.phases}φ · ${c.voltage} V</div>
+                  ` : ''}
+                </div>
+                <div class="load-prio ${pi.cls}"
+                  title="Order loads are switched off when grid current is too high">
+                  <ha-icon icon="mdi:shield-flash-outline"></ha-icon>
+                  <span>${pi.label}</span>
+                </div>
+              </div>
+            `;
+          })}
+        </div>
+        <div class="loads-foot">Loads are shed before battery power is reduced</div>
+      </div>
+    `;
+  }
+
   // Live preview: update local override and redraw immediately
   _previewPower(kw) {
     this._simOverrides = { ...this._simOverrides, powerKw: kw };
@@ -2279,6 +2339,157 @@ class FelicityEMSCard extends LitElement {
       }
       .ev-boost-banner ha-icon {
         --mdc-icon-size: 18px;
+      }
+
+      /* Flexible loads panel */
+      .loads-panel {
+        margin-bottom: 14px;
+        padding: 10px;
+        border-radius: 8px;
+        background: var(--secondary-background-color);
+      }
+      .loads-panel-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+      }
+      .loads-title {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.82rem;
+        font-weight: 600;
+        color: var(--primary-text-color);
+      }
+      .loads-title ha-icon {
+        --mdc-icon-size: 18px;
+        color: #00BCD4;
+      }
+      .loads-total {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--secondary-text-color);
+        font-variant-numeric: tabular-nums;
+      }
+      .loads-total.on {
+        color: #00BCD4;
+      }
+      .loads-list {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .load-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 8px;
+        border-radius: 6px;
+        background: var(--card-background-color);
+        border: 1px solid transparent;
+        opacity: 0.6;
+        transition: opacity 0.3s ease, box-shadow 0.3s ease;
+      }
+      .load-row.active {
+        opacity: 1;
+        border-color: rgba(0, 188, 212, 0.5);
+        box-shadow: 0 0 6px rgba(0, 188, 212, 0.22);
+      }
+      .load-glyph {
+        --mdc-icon-size: 22px;
+        flex: 0 0 auto;
+        color: var(--secondary-text-color);
+      }
+      .load-row.active .load-glyph {
+        color: #00BCD4;
+      }
+      .load-main {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .load-line {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.8rem;
+      }
+      .load-name {
+        font-weight: 500;
+        color: var(--primary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .load-power {
+        margin-left: auto;
+        color: var(--secondary-text-color);
+        font-variant-numeric: tabular-nums;
+      }
+      .load-row.active .load-power {
+        color: #00BCD4;
+        font-weight: 600;
+      }
+      .load-boost {
+        font-size: 0.6rem;
+        font-weight: 700;
+        letter-spacing: 0.5px;
+        padding: 1px 4px;
+        border-radius: 3px;
+        background: #00BCD4;
+        color: #00282d;
+      }
+      .load-bar {
+        margin-top: 4px;
+        height: 5px;
+        border-radius: 3px;
+        background: rgba(150, 150, 150, 0.25);
+        overflow: hidden;
+      }
+      .load-bar-fill {
+        height: 100%;
+        border-radius: 3px;
+        background: linear-gradient(90deg, #00BCD4, #4CAF50);
+        transition: width 0.4s ease;
+      }
+      .load-sub {
+        margin-top: 3px;
+        font-size: 0.68rem;
+        color: var(--secondary-text-color);
+        font-variant-numeric: tabular-nums;
+      }
+      .load-prio {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 3px;
+        font-size: 0.66rem;
+        font-weight: 600;
+        padding: 2px 6px;
+        border-radius: 10px;
+        white-space: nowrap;
+      }
+      .load-prio ha-icon {
+        --mdc-icon-size: 13px;
+      }
+      .load-prio.prio-first {
+        color: #ef5350;
+        background: rgba(239, 83, 80, 0.12);
+      }
+      .load-prio.prio-mid {
+        color: #FFB74D;
+        background: rgba(255, 152, 0, 0.12);
+      }
+      .load-prio.prio-last {
+        color: #66BB6A;
+        background: rgba(76, 175, 80, 0.12);
+      }
+      .loads-foot {
+        margin-top: 6px;
+        font-size: 0.66rem;
+        color: var(--secondary-text-color);
+        opacity: 0.8;
+        text-align: right;
       }
 
       /* Battery SOC indicator */

--- a/custom_components/ha_felicity/manifest.json
+++ b/custom_components/ha_felicity/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/partach/ha_felicity/issues",
   "requirements": ["pymodbus>=3.10.0"],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/custom_components/ha_felicity/sensor.py
+++ b/custom_components/ha_felicity/sensor.py
@@ -214,19 +214,46 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
             "rule1_window_warning": self.coordinator.rule1_window_warning,
             "flex_load_schedule": flex_slot_map,
             "flex_load_states": dict(self.coordinator._flex_load_states),
-            "flex_load_configs": [
-                {
-                    "index": i,
-                    "name": ld.name,
-                    "power_kw": ld.rated_power_kw,
-                    "priority": ld.priority,
-                    "is_ev": ld.is_ev_charger,
-                }
-                for i, ld in enumerate(self.coordinator._build_flex_load_configs())
-            ],
+            "flex_load_configs": self._build_flex_load_attr(),
             "ev_boost_active": self.coordinator.ev_boost_active,
             "ev_boost_remaining_min": self.coordinator.ev_boost_remaining_min,
         }
+
+    def _build_flex_load_attr(self) -> list[dict]:
+        """Build the per-load attribute list for the frontend card.
+
+        Includes the *actual* power each load is drawing right now so the
+        card can show "which load is active and with how much power":
+          - binary loads → rated power when on, else 0
+          - EV charger   → current step × voltage × phases (the real draw),
+            falling back to the startup current when no step has been set
+        """
+        states = self.coordinator._flex_load_states
+        ev_step = self.coordinator._flex_load_current_step
+        configs = []
+        for i, ld in enumerate(self.coordinator._build_flex_load_configs()):
+            is_on = bool(states.get(i, False))
+            entry = {
+                "index": i,
+                "name": ld.name,
+                "power_kw": round(ld.rated_power_kw, 2),
+                "priority": ld.priority,
+                "is_ev": ld.is_ev_charger,
+                "on": is_on,
+            }
+            if ld.is_ev_charger:
+                active_a = (ev_step if (is_on and ev_step) else ld.default_current)
+                max_a = max(ld.current_steps) if ld.current_steps else ld.default_current
+                entry["current_a"] = active_a if is_on else None
+                entry["phases"] = ld.phases
+                entry["voltage"] = ld.voltage
+                entry["max_power_kw"] = round(ld.power_at_current(max_a), 2)
+                entry["active_power_kw"] = round(ld.power_at_current(active_a), 2) if is_on else 0.0
+            else:
+                entry["max_power_kw"] = round(ld.rated_power_kw, 2)
+                entry["active_power_kw"] = round(ld.rated_power_kw, 2) if is_on else 0.0
+            configs.append(entry)
+        return configs
 
 
 class HA_FelicityChargeLikelihoodSensor(CoordinatorEntity, SensorEntity):

--- a/docs/flexible_loads.md
+++ b/docs/flexible_loads.md
@@ -81,3 +81,18 @@ During a boost:
 - **Cyan strip** at the bottom of price bars where loads are scheduled
 - **"N/M loads active"** stat in the stats row
 - **Cyan banner** during EV Boost showing remaining time
+- **Flexible Loads panel** — a dedicated section listing every configured
+  load with:
+  - **On/off state** — the row glows cyan and brightens when the load is
+    active, stays dim when off
+  - **Live power draw** — the current kW with a fill bar showing how much
+    of the load's maximum it is drawing. For the EV charger this is the
+    real draw (active current × voltage × phases), shown alongside the
+    `A · φ · V` detail
+  - **`BOOST` chip** — appears on the EV charger row while EV Boost is active
+  - **Shed-priority badge** — colour-coded ("Sheds 1st" red / "Sheds 2nd"
+    amber / "Sheds last" green) so you can see at a glance which load drops
+    off first when grid current is too high
+  - **Header total** — the combined live power of all active loads
+  - **Footer note** — a reminder that loads are shed before the battery
+    power is reduced


### PR DESCRIPTION
Show, per configured load: on/off state (dim → cyan glow), live power draw with a fill bar, the EV charger's active current (A·φ·V), a BOOST chip during EV boost, and a colour-coded shed-priority badge (Sheds 1st/2nd/last). Header shows total live kW; footer notes loads are shed before battery power is reduced.

Sensor now enriches flex_load_configs with on/active_power_kw/ max_power_kw and EV current/phases/voltage. EV active_power_kw is the real draw (current_step × voltage × phases), falling back to the startup current when no step is set.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF