### PR TITLE
EMS card: throttle/peak status, EV override button, EV charge strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,6 +536,25 @@ select.select_option).
 | `flexible_load_1_phases` | number (1-3) | EV only | — |
 | `flexible_load_1_voltage` | number (110-400V) | EV only | — |
 | `flexible_load_1_default_current` | number (6-32A) | EV only | — |
+| `ev_charge_strategy` | select (smart/solar_only/cheap_only/always_on) | EV only | — |
+
+### EV Charge Strategy
+
+`ev_charge_strategy` (config option + select entity, gated on
+`flexible_load_1_switch_entity`) shapes *when* the EV charger runs in
+`_schedule_flexible_loads`.  It applies only to the load with
+`is_ev_charger`; loads 2-3 always use the `smart` overlay.
+
+| Strategy | Slots scheduled |
+|---|---|
+| `smart` (default) | cheap ∨ negative ∨ PV-surplus ∨ battery-charge |
+| `solar_only` | PV-surplus only |
+| `cheap_only` | at/below threshold ∨ negative |
+| `always_on` | every remaining slot (safe-power then throttles current) |
+
+`always_on` differs from EV Boost: it's a persistent schedule at the
+scheduled current (not time-limited, not forced to max current).  Plumbed
+through `EMSConfig.ev_charge_strategy` → `_schedule_flexible_loads`.
 
 ### Frontend
 
@@ -581,7 +600,23 @@ soon" scenarios.
 
 **Frontend** (`ha_felicity_ems.js`):
 - Cyan banner above the chart: "EV Boost active — Xh Ym remaining"
+- **Override +1h button** in the card header (next to the battery
+  indicator), shown only when an EV charger is configured.  Resolves the
+  `button.*_ev_boost_*` entity (excluding the cancel button) and calls
+  `button.press` — each press adds an hour via the coordinator.
+- Status bar shows a **Boost Xh Ym** chip while active.
 - Auto-refreshes every minute while boost is active.
+
+### EMS Card Status Bar
+
+Below the Strategy dropdowns the card renders a status chip row
+(`status-bar`): operational mode, current price, **Active power X kW**
+(the live `safe_max_power`), **Peak Amp. X A** (`peak_grid_current_now`),
+and the boost chip.  The Active-power and Peak-Amp chips turn red when
+the inverter is being throttled (`safe_max_power < power_level`),
+surfacing safe-power current limiting at a glance.  The energy-state chip
+was removed (it duplicated the header badge).  This merges the status
+info that used to live in the inverter card's grey bottom bar.
 
 ---
 

--- a/custom_components/ha_felicity/__init__.py
+++ b/custom_components/ha_felicity/__init__.py
@@ -215,6 +215,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "flexible_load_1_phases": 1,
         "flexible_load_1_voltage": 230,
         "flexible_load_1_default_current": 16,
+        "ev_charge_strategy": "smart",
         "flexible_load_2_enabled": "off",
         "flexible_load_2_name": "",
         "flexible_load_2_switch_entity": "",

--- a/custom_components/ha_felicity/config_flow.py
+++ b/custom_components/ha_felicity/config_flow.py
@@ -107,6 +107,7 @@ class HA_FelicityConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "flexible_load_1_phases": 1,
             "flexible_load_1_voltage": 230,
             "flexible_load_1_default_current": 16,
+            "ev_charge_strategy": "smart",
             "flexible_load_2_enabled": "off",
             "flexible_load_2_name": "",
             "flexible_load_2_switch_entity": "",

--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -679,6 +679,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
                 "discharge_to_make_room_for_negative_price", "off"
             )).lower() in ("on", "true", "1"),
             flexible_loads=self._build_flex_load_configs(),
+            ev_charge_strategy=str(opts.get("ev_charge_strategy", "smart")),
         )
 
         state = ems_module.EMSState(

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -105,6 +105,14 @@ class EMSConfig:
     # Flexible loads (EV charger, boiler, etc.) — up to 3 controllable loads.
     # Scheduled into cheap/surplus slots alongside battery actions.
     flexible_loads: list[FlexibleLoadConfig] = field(default_factory=list)
+    # EV charge strategy (applies only to the EV charger, load 1):
+    #   smart      — overlay into cheap / negative / PV-surplus / charge slots
+    #                (cost-optimised, the default)
+    #   solar_only — only switch on when PV surplus is available (no grid)
+    #   cheap_only — only switch on at/below the price threshold or p<0
+    #   always_on  — always allowed on; the EMS only throttles the charge
+    #                current when grid current gets too high
+    ev_charge_strategy: str = "smart"
     # NOTE: battery State of Health (SOH) is applied by the coordinator
     # before constructing this config — it scales battery_capacity_kwh
     # by the SOH factor.  ems.py treats the capacity as already-effective.
@@ -918,6 +926,7 @@ def _schedule_flexible_loads(
     scheduled_slots: dict[int, str],
     price_threshold: float | None,
     pv_surplus_slots: set[int] | None = None,
+    ev_charge_strategy: str = "smart",
 ) -> dict[int, dict[int, bool]]:
     """Schedule flexible loads into cheap or PV-surplus slots.
 
@@ -925,6 +934,13 @@ def _schedule_flexible_loads(
     the battery.  A load is scheduled when the slot price is at or below
     the threshold, OR the slot has PV surplus.  Loads don't affect the
     battery schedule — they're additive consumption.
+
+    The EV charger (load with is_ev_charger) honours ``ev_charge_strategy``:
+      - smart      — cheap / negative / PV-surplus / battery-charge slots
+      - solar_only — only PV-surplus slots
+      - cheap_only — only at/below threshold or negative-price slots
+      - always_on  — every remaining slot (safe-power then throttles current)
+    All other loads always use the smart overlay.
 
     Returns {load_index: {slot_idx: True}} for each active slot.
     """
@@ -940,21 +956,32 @@ def _schedule_flexible_loads(
     pv_surplus = pv_surplus_slots or set()
 
     for load_idx, load in active_loads:
+        strategy = ev_charge_strategy if load.is_ev_charger else "smart"
         load_schedule: dict[int, bool] = {}
         for slot_idx, price in sorted_by_price:
             is_cheap = price_threshold is not None and price <= price_threshold
             is_pv_surplus = slot_idx in pv_surplus
             is_negative = price < 0
             already_charging = scheduled_slots.get(slot_idx) == "charge"
-            if is_cheap or is_pv_surplus or is_negative or already_charging:
+
+            if strategy == "always_on":
+                active = True
+            elif strategy == "solar_only":
+                active = is_pv_surplus
+            elif strategy == "cheap_only":
+                active = is_cheap or is_negative
+            else:  # smart
+                active = is_cheap or is_pv_surplus or is_negative or already_charging
+
+            if active:
                 load_schedule[slot_idx] = True
 
         if load_schedule:
             result[load_idx] = load_schedule
             _LOGGER.debug(
-                "Flexible load '%s' scheduled for %d slots",
+                "Flexible load '%s' scheduled for %d slots (strategy=%s)",
                 load.name or f"load_{load_idx + 1}",
-                len(load_schedule),
+                len(load_schedule), strategy,
             )
 
     return result
@@ -1590,6 +1617,7 @@ def calculate_schedule(config: EMSConfig, state: EMSState) -> ScheduleResult:
             result.scheduled_slots,
             flex_buy_threshold,
             pv_surplus_set,
+            config.ev_charge_strategy,
         )
 
     return result

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -1780,6 +1780,15 @@ class FelicityEMSCard extends LitElement {
       ? `${evBoostHours > 0 ? `${evBoostHours}h ` : ""}${evBoostMins}m remaining`
       : "";
     const operationalMode = this._getState("operational_mode") || null;
+    // Active power limit + grid current (for throttle display in status bar)
+    const powerLevelKw = this._getNumericState("power_level");
+    const safeMaxKw = this._getNumericState("safe_max_power") != null
+      ? this._getNumericState("safe_max_power") / 1000 : null;
+    const peakAmp = this._getNumericState("peak_grid_current_now");
+    const isThrottled = powerLevelKw != null && safeMaxKw != null
+      && safeMaxKw < powerLevelKw - 0.05;
+    // Show the EV override button only when an EV charger is configured
+    const evChargerConfigured = flexLoadConfigs.some((c) => c.is_ev);
     const pvRemaining = this._getNumericState("pv_forecast_remaining");
     const pvToday = this._getNumericState("pv_forecast_today");
     const pvTomorrow = this._getNumericState("pv_forecast_tomorrow");
@@ -1856,6 +1865,14 @@ class FelicityEMSCard extends LitElement {
             </div>
             <span class="battery-text">${this._fmt(socPct, 0)}% / ${batteryCapacity} kWh</span>
           </div>
+          ${evChargerConfigured ? html`
+            <button class="override-btn ${evBoostActive ? 'active' : ''}"
+              title="Force the EV charger on. Each press adds +1 hour of 'always on' (the EMS still throttles current if the grid limit is hit)."
+              @click=${() => this._pressEvBoost()}>
+              <ha-icon icon="mdi:ev-station"></ha-icon>
+              <span>Override +1h</span>
+            </button>
+          ` : ''}
           <div class="status-badges">
             <span class="badge ${energyState}">${energyState}</span>
             <span class="badge schedule-${scheduleStatus}">${scheduleStatus.replace(/_/g, ' ')}</span>
@@ -1989,11 +2006,22 @@ class FelicityEMSCard extends LitElement {
 
           <!-- Strategy & Status -->
           <div class="strategy-section">
-            ${this._renderStrategyControl()}
+            <div class="strategy-row">
+              ${this._renderStrategyControl()}
+              ${this._renderEvStrategyControl(evChargerConfigured)}
+            </div>
             <div class="status-bar">
               ${operationalMode ? html`<span class="status-chip mode">${operationalMode}</span>` : ''}
               <span class="status-chip price">${this._fmt(currentPrice, 3)} ${currency}/kWh</span>
-              <span class="status-chip state-${energyState}">${energyState}</span>
+              ${safeMaxKw != null ? html`
+                <span class="status-chip power ${isThrottled ? 'throttled' : ''}">Active power ${this._fmt(safeMaxKw, 1)} kW</span>
+              ` : ''}
+              ${peakAmp != null ? html`
+                <span class="status-chip amp ${isThrottled ? 'throttled' : ''}">Peak Amp. ${this._fmt(peakAmp, 0)} A</span>
+              ` : ''}
+              ${evBoostActive ? html`
+                <span class="status-chip boost">Boost ${evBoostHours}h${evBoostMins}m</span>
+              ` : ''}
             </div>
           </div>
 
@@ -2128,11 +2156,15 @@ class FelicityEMSCard extends LitElement {
     if (!entity) return html``;
     const parsedLevel = parseInt(entity.state);
     const display = this._simOverrides.priceLevel ?? (isNaN(parsedLevel) ? 5 : parsedLevel);
+    // In auto price mode the threshold is computed automatically — the manual
+    // level slider has no effect, so disable it.
+    const autoMode = this._getState("price_mode") === "auto";
 
     return html`
-      <div class="control-item">
-        <span class="control-label">Price Level ${display}/10</span>
+      <div class="control-item ${autoMode ? 'disabled' : ''}">
+        <span class="control-label">Price Level ${autoMode ? 'auto' : `${display}/10`}</span>
         <input type="range" min="1" max="10" step="1" .value=${display}
+          ?disabled=${autoMode}
           @input=${(e) => this._previewPriceLevel(parseInt(e.target.value))}
           @change=${(e) => this._commitPriceLevel(parseInt(e.target.value))} />
       </div>
@@ -2187,6 +2219,41 @@ class FelicityEMSCard extends LitElement {
         </select>
       </div>
     `;
+  }
+
+  _renderEvStrategyControl(show) {
+    if (!show) return html``;
+    const eid = this._getEntityId("ev_charge_strategy");
+    const current = eid && this.hass.states[eid]
+      ? this.hass.states[eid].state : "smart";
+    const options = [
+      { value: "smart", label: "EV: Smart" },
+      { value: "solar_only", label: "EV: Solar only" },
+      { value: "cheap_only", label: "EV: Cheapest" },
+      { value: "always_on", label: "EV: Always on" },
+    ];
+    return html`
+      <div class="strategy-control">
+        <select class="strategy-select"
+          title="How the EV charger is scheduled. Smart: cheap/solar/negative slots. Solar only: PV surplus. Cheapest: only at/below the price threshold. Always on: charge now, the EMS only throttles current if the grid limit is hit."
+          @change=${(e) => this._setSelect("ev_charge_strategy", e.target.value)}>
+          ${options.map((o) => html`
+            <option value="${o.value}" ?selected=${o.value === current}>${o.label}</option>
+          `)}
+        </select>
+      </div>
+    `;
+  }
+
+  // Find the EV Boost (+1h) button entity and press it.  Each press adds an
+  // hour of forced "always on" charging (the backend throttles current under
+  // safe-power if the grid limit is hit).
+  _pressEvBoost() {
+    const eid = (this._deviceEntities || []).find(
+      (e) => e.startsWith("button.") && e.includes("ev_boost") && !e.includes("cancel"),
+    );
+    if (!eid) return;
+    this.hass.callService("button", "press", { entity_id: eid });
   }
 
   _renderScheduleReason() {
@@ -2678,32 +2745,37 @@ class FelicityEMSCard extends LitElement {
       /* PV row */
       .pv-row {
         display: flex;
-        flex-wrap: wrap;
-        justify-content: space-around;
-        gap: 8px 0;
+        flex-wrap: nowrap;
+        justify-content: space-between;
+        gap: 4px;
         margin-bottom: 14px;
-        padding: 8px;
+        padding: 6px 8px;
         border-radius: 8px;
         background: var(--secondary-background-color);
       }
       .pv-item {
         display: flex;
         align-items: center;
-        gap: 6px;
+        gap: 4px;
+        min-width: 0;
       }
       .pv-item ha-icon {
-        --mdc-icon-size: 20px;
+        --mdc-icon-size: 17px;
         color: #FFD600;
+        flex: 0 0 auto;
       }
       .pv-label {
         display: block;
-        font-size: 0.7em;
+        font-size: 0.62em;
         color: var(--secondary-text-color);
+        white-space: nowrap;
       }
       .pv-value {
         display: block;
-        font-size: 0.9em;
+        font-size: 0.82em;
         font-weight: 500;
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
       }
 
       /* Controls */
@@ -2803,21 +2875,62 @@ class FelicityEMSCard extends LitElement {
         color: #f4b003;
         font-variant-numeric: tabular-nums;
       }
-      .status-chip.state-charging {
-        background: rgba(76, 175, 80, 0.18);
+      .status-chip.power,
+      .status-chip.amp {
+        background: rgba(76, 175, 80, 0.16);
         color: #4CAF50;
+        font-variant-numeric: tabular-nums;
+        text-transform: none;
       }
-      .status-chip.state-discharging {
-        background: rgba(255, 152, 0, 0.18);
-        color: #FF9800;
+      .status-chip.power.throttled,
+      .status-chip.amp.throttled {
+        background: rgba(244, 67, 54, 0.18);
+        color: #ef5350;
       }
-      .status-chip.state-idle {
-        background: var(--secondary-background-color);
-        color: var(--secondary-text-color);
+      .status-chip.boost {
+        background: rgba(0, 188, 212, 0.18);
+        color: #00BCD4;
+        text-transform: none;
       }
-      .status-chip.state-unknown {
-        background: var(--secondary-background-color);
-        color: var(--secondary-text-color);
+
+      /* Strategy dropdown row + EV override button */
+      .strategy-row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .strategy-row .strategy-control {
+        flex: 1;
+      }
+      .override-btn {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 10px;
+        border: 1px solid #00BCD4;
+        border-radius: 14px;
+        background: transparent;
+        color: #00BCD4;
+        font-size: 0.72em;
+        font-weight: 600;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .override-btn:hover {
+        background: rgba(0, 188, 212, 0.12);
+      }
+      .override-btn.active {
+        background: #00BCD4;
+        color: #00282d;
+      }
+      .override-btn ha-icon {
+        --mdc-icon-size: 16px;
+      }
+      .control-item.disabled {
+        opacity: 0.45;
+      }
+      .control-item.disabled input[type="range"] {
+        cursor: not-allowed;
       }
 
       /* Schedule reason ("why" line) */

--- a/custom_components/ha_felicity/manifest.json
+++ b/custom_components/ha_felicity/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/partach/ha_felicity/issues",
   "requirements": ["pymodbus>=3.10.0"],
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/custom_components/ha_felicity/select.py
+++ b/custom_components/ha_felicity/select.py
@@ -163,6 +163,21 @@ async def async_setup_entry(
         )
     )
 
+    # EV charge strategy — applies to the EV charger (load 1).  Gated on a
+    # switch entity being assigned to load 1.
+    entities.append(
+        HA_FelicitySpecialModeSelect(
+            coordinator=coordinator,
+            entry=entry,
+            option_key="ev_charge_strategy",
+            select_options=["smart", "solar_only", "cheap_only", "always_on"],
+            name="EV Charge Strategy",
+            icon="mdi:ev-station",
+            entity_category=EntityCategory.CONFIG,
+            requires_option="flexible_load_1_switch_entity",
+        )
+    )
+
     # Flexible load enable selects. Gated on a switch entity being assigned
     # to the load (assigned via the options flow).
     for i in range(1, 4):

--- a/docs/flexible_loads.md
+++ b/docs/flexible_loads.md
@@ -56,6 +56,31 @@ Examples:
 
 The **Rated Power** entity is for display only — the EMS uses the current/voltage/phases formula for actual EV charger control.
 
+## EV Charge Strategy
+
+The **EV Charge Strategy** select (load 1 only) controls *when* the EV charger
+is allowed to run. It's shown as a second dropdown next to the EMS Strategy on
+the card.
+
+| Strategy | When the EV charges | Use case |
+|---|---|---|
+| **Smart** (default) | Cheap slots, negative-price slots, PV-surplus slots, and battery-charge slots | Cost-optimised everyday charging |
+| **Solar only** | Only when PV production exceeds house consumption | Charge purely from your own solar, never from the grid |
+| **Cheapest** | Only at/below the price threshold or when price is negative | Pure price control, ignore solar timing |
+| **Always on** | Every slot — the charger is always allowed on | "Charge now no matter what." The EMS only steps the current down if the grid current limit is reached |
+
+The strategy only affects the EV charger (load 1). Loads 2 and 3 always use the
+Smart overlay.
+
+## EV Override (Boost)
+
+The **Override +1h** button (top of the EMS card, next to the battery
+indicator) forces the EV charger on at maximum current. Each press adds one
+more hour. While active, the card shows a **Boost Xh Ym** chip in the status
+bar. Safe-power protection can still step the current down during a boost (grid
+safety), but the charger won't be fully switched off. The boost expires
+automatically when the timer runs out.
+
 ## Safe Power Protection
 
 When grid current exceeds the **Max Amperage Per Phase** limit, loads are shed in this order:

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -48,6 +48,7 @@ _project_soc_trajectory = ems._project_soc_trajectory
 _validate_schedule_soc = ems._validate_schedule_soc
 _compute_reserve_target = ems._compute_reserve_target
 _compute_tomorrow_schedule = ems._compute_tomorrow_schedule
+_schedule_flexible_loads = ems._schedule_flexible_loads
 
 
 # ---------------------------------------------------------------------------
@@ -4717,3 +4718,68 @@ class TestFlexibleLoadConfig:
         """Three phase power calculation."""
         load = FlexibleLoadConfig(phases=3, voltage=230)
         assert abs(load.power_at_current(16) - 11.04) < 0.01
+
+
+class TestEVChargeStrategy:
+    """Tests for the EV charge strategy applied in _schedule_flexible_loads."""
+
+    def _ev_load(self):
+        return FlexibleLoadConfig(
+            enabled=True,
+            name="EV",
+            switch_entity="switch.ev",
+            current_entity="number.ev_current",
+            current_steps=[6, 10, 16],
+        )
+
+    def _binary_load(self):
+        return FlexibleLoadConfig(
+            enabled=True, name="Boiler", switch_entity="switch.boiler",
+        )
+
+    def _remaining(self):
+        # 6 slots: 0,1 cheap; 2 negative; 3,4,5 expensive
+        return [(0, 0.05), (1, 0.06), (2, -0.02), (3, 0.30), (4, 0.31), (5, 0.32)]
+
+    def test_smart_default(self):
+        """smart: cheap + negative + pv-surplus + charge slots."""
+        res = _schedule_flexible_loads(
+            [self._ev_load()], self._remaining(), {3: "charge"},
+            price_threshold=0.10, pv_surplus_slots={4}, ev_charge_strategy="smart",
+        )
+        slots = set(res[0].keys())
+        assert slots == {0, 1, 2, 3, 4}  # cheap 0,1; neg 2; charge 3; pv 4
+
+    def test_always_on(self):
+        """always_on: every remaining slot is scheduled regardless of price."""
+        res = _schedule_flexible_loads(
+            [self._ev_load()], self._remaining(), {},
+            price_threshold=0.10, pv_surplus_slots=set(), ev_charge_strategy="always_on",
+        )
+        assert set(res[0].keys()) == {0, 1, 2, 3, 4, 5}
+
+    def test_solar_only(self):
+        """solar_only: only PV-surplus slots, even if cheap/negative."""
+        res = _schedule_flexible_loads(
+            [self._ev_load()], self._remaining(), {3: "charge"},
+            price_threshold=0.10, pv_surplus_slots={4, 5}, ev_charge_strategy="solar_only",
+        )
+        assert set(res[0].keys()) == {4, 5}
+
+    def test_cheap_only(self):
+        """cheap_only: at/below threshold or negative; ignores PV surplus."""
+        res = _schedule_flexible_loads(
+            [self._ev_load()], self._remaining(), {},
+            price_threshold=0.10, pv_surplus_slots={5}, ev_charge_strategy="cheap_only",
+        )
+        # cheap 0,1 + negative 2; NOT the pv-surplus expensive slot 5
+        assert set(res[0].keys()) == {0, 1, 2}
+
+    def test_strategy_only_affects_ev(self):
+        """Non-EV loads always use the smart overlay, ignoring ev_charge_strategy."""
+        res = _schedule_flexible_loads(
+            [self._binary_load()], self._remaining(), {},
+            price_threshold=0.10, pv_surplus_slots={5}, ev_charge_strategy="always_on",
+        )
+        # Binary load uses smart: cheap 0,1 + negative 2 + pv-surplus 5
+        assert set(res[0].keys()) == {0, 1, 2, 5}


### PR DESCRIPTION
1) Remove duplicate energy-state chip below the strategy (already shown
   as a header badge next to the schedule status).
2) Status bar now shows Active power (live safe_max_power) and Peak Amp.
   (peak_grid_current_now); both turn red when the inverter is throttled
   (safe_max_power < power_level).
3) Add an "Override +1h" button in the card header (shown when an EV
   charger is configured) that presses the EV Boost button entity; a
   "Boost Xh Ym" chip appears in the status bar while active.
4) Add an EV Charge Strategy dropdown next to the EMS Strategy:
   smart (default) / solar_only / cheap_only / always_on. Plumbed through
   EMSConfig.ev_charge_strategy into _schedule_flexible_loads (EV load
   only). New select entity + option defaults.
5) Grey out / disable the Price Level slider when price mode is auto. 6) Denser PV forecast row (no-wrap, smaller fonts/icons/gaps).

Tests: +5 for EV charge strategy (203 total).

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF