### PR TITLE
Add tomorrow flex load schedule with proper EV strategy support

### DIFF
--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -164,6 +164,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self._flex_load_states: dict[int, bool] = {}  # {load_idx: on/off}
         self._flex_load_current_step: int | None = None
         self._flex_load_scheduled: dict[int, dict[int, bool]] = {}  # from ScheduleResult.load_slots
+        self._flex_load_scheduled_tomorrow: dict[int, dict[int, bool]] = {}
         self._ev_boost_until_ts: float = 0.0  # epoch ts — EV override active when now < this
         # Max current applied for the current boost session.  Applied once
         # (not every tick) so safe-power step-downs aren't fought; reset on
@@ -829,6 +830,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self._tomorrow_scheduled_slots = result.tomorrow_scheduled_slots
         self._backend_soc_trajectory_tomorrow = result.tomorrow_soc_trajectory
         self._flex_load_scheduled = result.load_slots
+        self._flex_load_scheduled_tomorrow = result.tomorrow_load_slots
 
         if result.price_threshold is not None:
             self.price_threshold = result.price_threshold

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -169,6 +169,7 @@ class ScheduleResult:
     tomorrow_soc_trajectory: list[float] = field(default_factory=list)
     # Flexible load schedules: {load_index: {slot_idx: True}}
     load_slots: dict[int, dict[int, bool]] = field(default_factory=dict)
+    tomorrow_load_slots: dict[int, dict[int, bool]] = field(default_factory=dict)
 
 
 @dataclass
@@ -1596,9 +1597,9 @@ def calculate_schedule(config: EMSConfig, state: EMSState) -> ScheduleResult:
     # Schedule flexible loads into cheap / PV-surplus slots
     active_loads = [ld for ld in config.flexible_loads if ld.enabled]
     if active_loads:
+        cons_per_hour = config.consumption_est_kwh / 24.0
         pv_surplus_set = set()
         if state.pv_hourly_kwh:
-            cons_per_hour = config.consumption_est_kwh / 24.0
             for slot_idx, _ in remaining:
                 hr = int((slot_idx * minutes_per_slot) / 60) % 24
                 pv_hr = state.pv_hourly_kwh.get(hr, 0.0)
@@ -1619,6 +1620,31 @@ def calculate_schedule(config: EMSConfig, state: EMSState) -> ScheduleResult:
             pv_surplus_set,
             config.ev_charge_strategy,
         )
+
+        # Tomorrow's flex load schedule (same strategy, tomorrow's data)
+        if state.slot_prices_tomorrow:
+            tmr_remaining = list(enumerate(state.slot_prices_tomorrow))
+            tmr_pv_surplus = set()
+            pv_tmr = state.pv_hourly_kwh_tomorrow or {}
+            if pv_tmr:
+                for slot_idx, _ in tmr_remaining:
+                    hr = int((slot_idx * minutes_per_slot) / 60) % 24
+                    pv_hr = pv_tmr.get(hr, 0.0)
+                    if pv_hr > cons_per_hour:
+                        tmr_pv_surplus.add(slot_idx)
+            tmr_charge_prices = [
+                p for i, p in tmr_remaining
+                if result.tomorrow_scheduled_slots.get(i) == "charge"
+            ]
+            tmr_threshold = max(tmr_charge_prices) if tmr_charge_prices else flex_buy_threshold
+            result.tomorrow_load_slots = _schedule_flexible_loads(
+                config.flexible_loads,
+                tmr_remaining,
+                result.tomorrow_scheduled_slots,
+                tmr_threshold,
+                tmr_pv_surplus,
+                config.ev_charge_strategy,
+            )
 
     return result
 

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -844,7 +844,9 @@ class FelicityEMSCard extends LitElement {
     const currentSlot = showTomorrow ? -1 : currentSlotIdx;
 
     // Flexible load schedule: {slot_index: [load indices]} from the backend
-    const flexSchedule = this._getAttr("schedule_status", "flex_load_schedule") || {};
+    const flexSchedule = showTomorrow
+      ? (this._getAttr("schedule_status", "flex_load_schedule_tomorrow") || {})
+      : (this._getAttr("schedule_status", "flex_load_schedule") || {});
 
     // Draw bars
     for (let i = 0; i < numSlots; i++) {

--- a/custom_components/ha_felicity/sensor.py
+++ b/custom_components/ha_felicity/sensor.py
@@ -146,6 +146,10 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
         for load_idx, slots in (self.coordinator._flex_load_scheduled or {}).items():
             for slot in slots:
                 flex_slot_map.setdefault(str(slot), []).append(load_idx)
+        flex_slot_map_tomorrow: dict[str, list[int]] = {}
+        for load_idx, slots in (self.coordinator._flex_load_scheduled_tomorrow or {}).items():
+            for slot in slots:
+                flex_slot_map_tomorrow.setdefault(str(slot), []).append(load_idx)
 
         # Effective capacity (nominal × SOH) — what the scheduler actually
         # plans with.  The client-side simulation must use the same value
@@ -213,6 +217,7 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
             "slot_overrides": self.coordinator.slot_overrides if self.coordinator.slot_overrides else {},
             "rule1_window_warning": self.coordinator.rule1_window_warning,
             "flex_load_schedule": flex_slot_map,
+            "flex_load_schedule_tomorrow": flex_slot_map_tomorrow,
             "flex_load_states": dict(self.coordinator._flex_load_states),
             "flex_load_configs": self._build_flex_load_attr(),
             "ev_boost_active": self.coordinator.ev_boost_active,

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -4783,3 +4783,67 @@ class TestEVChargeStrategy:
         )
         # Binary load uses smart: cheap 0,1 + negative 2 + pv-surplus 5
         assert set(res[0].keys()) == {0, 1, 2, 5}
+
+    def test_tomorrow_flex_schedule_uses_ev_strategy(self):
+        """Tomorrow's flex load schedule should honour the EV charge strategy."""
+        prices_today = [0.10] * 24
+        prices_tomorrow = [0.05] * 8 + [0.25] * 8 + [0.10] * 8  # cheap morning, expensive mid, medium evening
+        pv_tomorrow = {h: 3.0 for h in range(8, 16)}  # PV 08-16
+
+        config = EMSConfig(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10,
+            safe_power_kw=5,
+            inverter_max_power_kw=10,
+            consumption_est_kwh=10,
+            ev_charge_strategy="always_on",
+            flexible_loads=[self._ev_load()],
+        )
+        state = EMSState(
+            slot_prices_today=prices_today,
+            slot_prices_tomorrow=prices_tomorrow,
+            pv_hourly_kwh={},
+            pv_hourly_kwh_tomorrow=pv_tomorrow,
+            battery_soc_pct=80.0,
+            pv_actual_today_kwh=0,
+            current_hour=23,
+            current_minute=0,
+        )
+        result = calculate_schedule(config, state)
+
+        # With always_on, every tomorrow slot should be scheduled
+        assert result.tomorrow_load_slots, "tomorrow_load_slots should not be empty"
+        ev_slots = result.tomorrow_load_slots.get(0, {})
+        assert len(ev_slots) == 24, f"always_on should schedule all 24 slots, got {len(ev_slots)}"
+
+    def test_tomorrow_flex_schedule_solar_only(self):
+        """Tomorrow solar_only strategy should only schedule PV-surplus slots."""
+        prices_today = [0.10] * 24
+        prices_tomorrow = [0.10] * 24
+        pv_tomorrow = {10: 3.0, 11: 4.0, 12: 5.0}  # PV only 10-12
+
+        config = EMSConfig(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10,
+            safe_power_kw=5,
+            inverter_max_power_kw=10,
+            consumption_est_kwh=10,
+            ev_charge_strategy="solar_only",
+            flexible_loads=[self._ev_load()],
+        )
+        state = EMSState(
+            slot_prices_today=prices_today,
+            slot_prices_tomorrow=prices_tomorrow,
+            pv_hourly_kwh={},
+            pv_hourly_kwh_tomorrow=pv_tomorrow,
+            battery_soc_pct=80.0,
+            pv_actual_today_kwh=0,
+            current_hour=23,
+            current_minute=0,
+        )
+        result = calculate_schedule(config, state)
+        ev_slots = result.tomorrow_load_slots.get(0, {})
+        # Only PV surplus hours (consumption ~0.42 kWh/h, PV 3-5 kWh/h → surplus at 10,11,12)
+        for slot_idx in ev_slots:
+            hour = slot_idx  # 24-slot granularity → slot == hour
+            assert hour in pv_tomorrow, f"solar_only slot {slot_idx} has no PV"


### PR DESCRIPTION
Tomorrow's graph was showing today's flex load bars because no tomorrow-specific flex schedule existed. The fix:

- ems.py: compute tomorrow_load_slots by calling _schedule_flexible_loads with tomorrow's prices, PV surplus, and the current ev_charge_strategy. Added tomorrow_load_slots field to ScheduleResult.
- coordinator.py: store _flex_load_scheduled_tomorrow from result.
- sensor.py: expose flex_load_schedule_tomorrow in schedule_status attrs.
- frontend: use flex_load_schedule_tomorrow when showing Tomorrow view.
- tests: two new tests verifying always_on and solar_only strategies are correctly applied to tomorrow's flex load schedule.

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF