### PR TITLE
Fix both-mode not charging today when tomorrow is cheaper

### DIFF
--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -2078,6 +2078,52 @@ def _schedule_both(
     result.tomorrow_planned_slots = len(tomorrow_slots)
     result.tomorrow_planned_kwh = tomorrow_charge_kwh
 
+    # --- Today sell-coverage pass ---
+    # The unified charge selection picks globally-cheapest slots, which may
+    # all land on tomorrow when tomorrow is cheaper.  But tomorrow's charge
+    # can't support today's sells — the energy isn't there yet.  When
+    # arbitrage is active and today has profitable sell candidates, ensure
+    # enough today charge slots exist to support them.
+    if arbitrage_active and not charge_slots:
+        today_charge_indices = {s[0] for s in charge_slots}
+        # Quick check: are there today sell candidates worth chasing?
+        sell_floor = 0.0
+        if config.arbitrage_price_delta > 0:
+            cheapest_today = min((p for _, p in remaining), default=0)
+            sell_floor = cheapest_today + config.arbitrage_price_delta
+        today_sell_candidates = [
+            (i, p) for i, p in remaining
+            if p > sell_floor and p > 0 and i not in today_charge_indices
+        ]
+        if today_sell_candidates:
+            # How much can we sell from current SOC + PV alone?
+            available_to_sell = max(0.0, current_kwh + net_pv - reserve_target)
+            # How much do we want to sell?
+            desired_sell_kwh = len(today_sell_candidates) * energy_per_slot * config.efficiency
+            sell_shortfall = max(0.0, min(desired_sell_kwh, max_battery_kwh - reserve_target) - available_to_sell)
+            if sell_shortfall > effective_per_slot * 0.5:
+                # Add today's cheapest non-sell slots as charge slots
+                today_pool = sorted(
+                    [(i, p) for i, p in remaining
+                     if i not in today_charge_indices
+                     and i not in {s[0] for s in today_sell_candidates}],
+                    key=lambda x: x[1],
+                )
+                added = 0.0
+                for slot in today_pool:
+                    if added >= sell_shortfall:
+                        break
+                    charge_slots.append(slot)
+                    today_charge_indices.add(slot[0])
+                    added += effective_per_slot
+                if added > 0:
+                    _LOGGER.debug(
+                        "Sell-coverage: added %.1f kWh in %d today charge slots "
+                        "to support today's %d sell candidates (shortfall=%.1f kWh)",
+                        added, sum(1 for s in charge_slots if s[0] < num_slots),
+                        len(today_sell_candidates), sell_shortfall,
+                    )
+
     # Sellable energy: peak projected SOC above reserve.
     # After charge selection, include the planned charge energy so the sell
     # side knows the battery will have surplus to sell.  Without this, a low

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -4847,3 +4847,62 @@ class TestEVChargeStrategy:
         for slot_idx in ev_slots:
             hour = slot_idx  # 24-slot granularity → slot == hour
             assert hour in pv_tomorrow, f"solar_only slot {slot_idx} has no PV"
+
+
+class TestSellCoverage:
+    """Ensure both-mode charges today when today has profitable sell slots."""
+
+    def test_sell_coverage_adds_today_charge_slots(self):
+        """When tomorrow is cheaper but today has sells, charge today too.
+
+        Reproduces the bug where unified slot selection put all charge
+        slots on tomorrow, leaving today's battery too low to sell in the
+        evening — dropping 6+ profitable sell slots.
+        """
+        # 24-slot (hourly) granularity for simplicity.
+        # Today: cheap afternoon (0.03), expensive evening (0.25+).
+        # Tomorrow: very cheap overnight (0.01).
+        today_prices = (
+            [0.10] * 14  # 00-13: morning (past, slot 14 = current)
+            + [0.03, 0.03, 0.04, 0.04]  # 14-17: cheap afternoon
+            + [0.25, 0.26, 0.27, 0.25, 0.24, 0.23]  # 18-23: expensive evening
+        )
+        tomorrow_prices = (
+            [0.01] * 6 + [0.03] * 6  # 00-11: very cheap
+            + [0.08] * 6  # 12-17
+            + [0.20] * 6  # 18-23
+        )
+        config = EMSConfig(
+            grid_mode="both",
+            battery_capacity_kwh=60,
+            battery_charge_max_pct=100,
+            battery_discharge_min_pct=20,
+            safe_power_kw=15,
+            inverter_max_power_kw=25,
+            consumption_est_kwh=5,
+            efficiency=0.90,
+            arbitrage_price_delta=0.15,
+        )
+        state = EMSState(
+            slot_prices_today=today_prices,
+            slot_prices_tomorrow=tomorrow_prices,
+            battery_soc_pct=52.0,  # ~31.2 kWh of 60
+            pv_hourly_kwh={},
+            pv_actual_today_kwh=0,
+            current_hour=14,
+            current_minute=0,
+        )
+        result = calculate_schedule(config, state)
+
+        # The algorithm must schedule some charge slots TODAY (not all tomorrow)
+        today_charges = [i for i, a in result.scheduled_slots.items() if a == "charge"]
+        assert len(today_charges) > 0, (
+            "Expected today charge slots to support evening sells, "
+            f"but got 0.  Scheduled: {result.scheduled_slots}"
+        )
+
+        # And it must schedule sell slots in the expensive evening window
+        today_sells = [i for i, a in result.scheduled_slots.items() if a == "discharge"]
+        assert len(today_sells) >= 2, (
+            f"Expected profitable evening sells, got {len(today_sells)}: {today_sells}"
+        )


### PR DESCRIPTION
When unified charge selection found cheaper slots on tomorrow, it allocated ALL charge slots there — leaving zero today. But tomorrow's charge can't support today's sells: the battery drains from consumption, SOC validation drops 6+ profitable evening sell slots, and the user misses revenue.

New "sell coverage" pass in _schedule_both: after unified selection, if arbitrage is active and no today charge slots were selected but today has profitable sell candidates, compute the sell shortfall (desired sell energy - available SOC - PV) and add today's cheapest remaining slots to the charge set.

Adds TestSellCoverage with a test reproducing the exact scenario (battery at 52%, cheap afternoon, expensive evening, cheaper tomorrow overnight).

https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF