### PR TITLE
Surface active scheduler engine in card status bar

### DIFF
--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -98,6 +98,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self.grid_energy_planned: float = 0.0
         self.schedule_status: str = "unknown"
         self.schedule_reason: str = ""
+        self.scheduler_active: str = "greedy"
 
         # Consumption tracking & persistent storage
         self.consumption_override_entity = consumption_override_entity
@@ -828,6 +829,7 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
         self.tomorrow_planned_kwh = result.tomorrow_planned_kwh
         self.schedule_status = result.status
         self.schedule_reason = result.schedule_reason
+        self.scheduler_active = result.scheduler_active
         self._backend_soc_trajectory = result.soc_trajectory
         self._tomorrow_scheduled_slots = result.tomorrow_scheduled_slots
         self._backend_soc_trajectory_tomorrow = result.tomorrow_soc_trajectory

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -169,6 +169,7 @@ class ScheduleResult:
     tomorrow_precharge: float = 0.0
     status: str = "off"
     schedule_reason: str = ""
+    scheduler_active: str = "greedy"  # "greedy" | "milp" | "greedy_fallback"
     soc_trajectory: list[float] = field(default_factory=list)
     tomorrow_scheduled_slots: dict[int, str] = field(default_factory=dict)
     tomorrow_soc_trajectory: list[float] = field(default_factory=list)
@@ -1497,6 +1498,7 @@ def _run_milp_or_none(
     scheduled, tomorrow_scheduled = milp_result
 
     result = ScheduleResult()
+    result.scheduler_active = "milp"
     result.scheduled_slots = scheduled
     result.tomorrow_scheduled_slots = tomorrow_scheduled
     result.self_consumption_reserve = round(reserve_kwh, 2)
@@ -1657,6 +1659,7 @@ def calculate_schedule(config: EMSConfig, state: EMSState) -> ScheduleResult:
         )
         if result is None:
             result = _run_greedy()
+            result.scheduler_active = "greedy_fallback"
     else:
         result = _run_greedy()
 

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -1782,6 +1782,8 @@ class FelicityEMSCard extends LitElement {
       ? `${evBoostHours > 0 ? `${evBoostHours}h ` : ""}${evBoostMins}m remaining`
       : "";
     const operationalMode = this._getState("operational_mode") || null;
+    const schedulerActive = this._getAttr("schedule_status", "scheduler_active") || null;
+    const schedulerEngine = this._getState("scheduler_engine") || "greedy";
     // Active power limit + grid current (for throttle display in status bar)
     const powerLevelKw = this._getNumericState("power_level");
     const safeMaxKw = this._getNumericState("safe_max_power") != null
@@ -2018,6 +2020,9 @@ class FelicityEMSCard extends LitElement {
             </div>
             <div class="status-bar">
               ${operationalMode ? html`<span class="status-chip mode">${operationalMode}</span>` : ''}
+              ${schedulerEngine === "milp" ? html`
+                <span class="status-chip engine ${schedulerActive === 'greedy_fallback' ? 'fallback' : ''}">${schedulerActive === 'milp' ? 'MILP' : schedulerActive === 'greedy_fallback' ? 'Greedy (fallback)' : 'Greedy'}</span>
+              ` : ''}
               ${safeMaxKw != null ? html`
                 <span class="status-chip power ${isThrottled ? 'throttled' : ''}">Active power ${this._fmt(safeMaxKw, 1)} kW</span>
               ` : ''}
@@ -2930,6 +2935,15 @@ class FelicityEMSCard extends LitElement {
       .status-chip.amp.throttled {
         background: rgba(244, 67, 54, 0.18);
         color: #ef5350;
+      }
+      .status-chip.engine {
+        background: rgba(156, 39, 176, 0.16);
+        color: #AB47BC;
+        text-transform: none;
+      }
+      .status-chip.engine.fallback {
+        background: rgba(255, 152, 0, 0.18);
+        color: #FF9800;
       }
       .status-chip.boost {
         background: rgba(0, 188, 212, 0.18);

--- a/custom_components/ha_felicity/sensor.py
+++ b/custom_components/ha_felicity/sensor.py
@@ -172,6 +172,7 @@ class HA_FelicityScheduleStatusSensor(CoordinatorEntity, SensorEntity):
 
         return {
             "schedule_reason": self.coordinator.schedule_reason,
+            "scheduler_active": self.coordinator.scheduler_active,
             "cheap_slots_remaining": self.coordinator.cheap_slots_remaining,
             "grid_energy_planned_kwh": self.coordinator.grid_energy_planned,
             "scheduled_slot_count": len(scheduled),

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -4963,6 +4963,7 @@ class TestMILPScheduler:
         # Cheap slots are 0-5; charging should prefer those.
         assert all(i < 6 for i in charges), f"Expected cheap-slot charging, got {charges}"
         assert "MILP" in result.schedule_reason
+        assert result.scheduler_active == "milp"
 
     def test_milp_arbitrage_both_mode(self):
         """MILP both: buy cheap + sell expensive when spread is profitable."""
@@ -5097,6 +5098,28 @@ class TestMILPScheduler:
         result = calculate_schedule(config, state)
         # Greedy still produces a schedule (no MILP reason string).
         assert "MILP" not in result.schedule_reason
+        assert result.scheduler_active == "greedy_fallback"
+
+    def test_greedy_scheduler_active_field(self):
+        """Default greedy engine sets scheduler_active='greedy'."""
+        config = EMSConfig(
+            grid_mode="from_grid",
+            battery_capacity_kwh=10,
+            battery_discharge_min_pct=20,
+            safe_power_kw=5,
+            consumption_est_kwh=5,
+            reserve_target_pct=50,
+        )
+        state = EMSState(
+            slot_prices_today=[0.05] * 6 + [0.30] * 6,
+            battery_soc_pct=10.0,
+            pv_hourly_kwh={},
+            pv_actual_today_kwh=0,
+            current_hour=0,
+            current_minute=0,
+        )
+        result = calculate_schedule(config, state)
+        assert result.scheduler_active == "greedy"
 
 
 def _grid_cost_of_schedule(config, state, today_sched, tomorrow_sched):


### PR DESCRIPTION
New scheduler_active field on ScheduleResult tracks which engine actually ran: "milp", "greedy", or "greedy_fallback" (when user selected MILP but the solver failed/was unavailable). Plumbed through coordinator → sensor attribute → frontend.

The card shows an engine status chip (purple "MILP" / amber "Greedy (fallback)") in the status bar when the user has selected the MILP engine. Not shown when engine is plain greedy (no visual clutter for the default). This makes silent fallback visible instead of the user wondering why their MILP selection isn't doing anything different.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF