### PR TITLE
Fix reserve_target_pct: monotonic floor (max of fixed + dynamic), nev…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ This prevents the SOC prediction from assuming unrealistic charge rates
 | inverter_max_power_kw | 10.0 | Total inverter power limit (model-specific) |
 | consumption_est_kwh | 10.0 | Daily consumption (or 7-day rolling avg) |
 | yesterday_deficit_kwh | 0.0 | Carried forward from previous day; reset on grid_mode change |
-| reserve_target_pct | 0.0 | 0=dynamic, >0=fixed floor % |
+| reserve_target_pct | 0.0 | 0=dynamic; >0=monotonic floor, max(fixed, dynamic) — only raises |
 | arbitrage_price_delta | 0.0 | Min buy→sell spread to trade in 'both' mode (>0 gates sells at buy+delta; 0 = automatic profitability check) |
 | battery_cycle_cost_eur_kwh | 0.0 | Wear cost; added to min sell price |
 | optimization_priority | "cost" | cost / longevity / self_consumption |
@@ -305,21 +305,42 @@ already-effective.  SOH is estimated from cumulative cycle throughput
 
 ### Core Concept: Reserve Target
 
-The algorithm does NOT try to fill the battery to 100%. It calculates a **reserve target** — just enough to survive overnight:
+The algorithm does NOT try to fill the battery to 100%. It calculates a **reserve target** — the minimum SOC to maintain at all times. By default that's "just enough to survive overnight"; the user can raise it with `reserve_target_pct`:
 
 ```
-Dynamic (reserve_target_pct = 0):
-  reserve_target = discharge_min_kwh + overnight_reserve
+dynamic_reserve = discharge_min_kwh + overnight_reserve × boost
   where overnight_reserve = consumption_per_hour × (24 - sunset + sunrise)
+        boost = 1.25 if optimization_priority == "self_consumption" else 1.0
+
+Dynamic (reserve_target_pct = 0):
+  reserve_target = dynamic_reserve
 
 Fixed (reserve_target_pct > 0):
-  reserve_target = max(reserve_target_pct × capacity, discharge_min_kwh)
+  reserve_target = max(reserve_target_pct × capacity, dynamic_reserve)
 ```
+
+**`reserve_target_pct` is a MONOTONIC FLOOR — it can only RAISE the target,
+never lower it.** This is the whole point of the setting: "keep AT LEAST this
+much in the battery at all times." A higher value keeps the battery fuller
+and pulls more charging into *today* (the deficit / midnight-constraint logic
+charges to reach the reserve).
+
+⚠️ **Fixed June 2026** (was a real, user-reported bug): the old formula was
+`max(reserve_target_pct × capacity, discharge_min_kwh)` — it ignored the
+dynamic overnight reserve and the self_consumption boost entirely. So a fixed
+reserve *below* the dynamic value would **lower** the target and charge the
+battery LESS full than `reserve_target_pct = 0` would. Setting "I want more
+reserve" produced "charge less full." Now `max(fixed, dynamic)` makes it
+monotonic. Lives in `_compute_reserve_target` (single source) → greedy and
+MILP both inherit it; the tomorrow-side reserve in `select_unified_charge_slots`
+and both JS-card mirrors apply the same `max(fixed, dynamic)` rule.
 
 Example: 60 kWh battery, 35% min, 38.5 kWh/d consumption, sunset 19:00, sunrise 7:00
 - min_kwh = 21 kWh
 - overnight = (38.5/24) × 12h = 19.25 kWh → rounds to ~19.3 kWh
-- reserve_target = 21 + 19.3 = 40.3 kWh (~67% of 60 kWh)
+- dynamic reserve_target = 21 + 19.3 = 40.3 kWh (~67% of 60 kWh)
+- A user setting reserve_target_pct=35% (21 kWh) does NOT lower it to 21 —
+  `max(21, 40.3) = 40.3 kWh` stands. Setting 80% (48 kWh) raises it to 48.
 
 **Reserve exposed even when scheduler is disabled**: `calculate_schedule`
 short-circuits when `grid_mode == "off"` (or no price data), but it still
@@ -773,7 +794,7 @@ info that used to live in the inverter card's grey bottom bar.
 | battery_capacity_kwh | number | 1-200 kWh | 10 | Usable battery capacity |
 | efficiency_factor | number | 0.70-1.00 | 0.90 | Round-trip efficiency |
 | daily_consumption_estimate | number | 0-120 kWh | 10 | Fallback consumption |
-| reserve_target_pct | number | 0-100% | 0 | Fixed reserve floor (0=dynamic) |
+| reserve_target_pct | number | 0-100% | 0 | Monotonic reserve floor — max(fixed, dynamic), only raises (0=dynamic) |
 | arbitrage_price_delta | number | 0-0.50 €/kWh | 0 | Min buy→sell spread to trade (0=auto profitability) |
 | battery_cycle_cost_eur_kwh | number | 0-0.50 €/kWh | 0 | Battery wear cost (profitability filter) |
 | optimization_priority | select | cost/longevity/self_consumption | cost | Multi-objective strategy |

--- a/custom_components/ha_felicity/ems.py
+++ b/custom_components/ha_felicity/ems.py
@@ -258,15 +258,29 @@ def _compute_reserve_target(
     """
     min_kwh = (config.battery_discharge_min_pct / 100.0) * config.battery_capacity_kwh
 
+    # Dynamic overnight-survival reserve: discharge floor + the energy needed
+    # to ride from sunset to sunrise.  self_consumption holds an extra 25% to
+    # favour PV self-use over grid exports.
+    multiplier = 1.25 if config.optimization_priority == "self_consumption" else 1.0
+    dynamic_reserve = min_kwh + reserve_kwh * multiplier
+
     if config.reserve_target_pct > 0:
         fixed_floor = (config.reserve_target_pct / 100.0) * config.battery_capacity_kwh
-        # Use the higher of fixed floor and discharge minimum
-        return min(config.battery_capacity_kwh, max(fixed_floor, min_kwh))
+        # A user-set reserve means "keep AT LEAST this much in the battery at
+        # all times."  It can only RAISE the target — never push it below the
+        # dynamic overnight-survival need (or the hardware discharge minimum,
+        # which dynamic_reserve already includes).  Taking the max makes the
+        # knob monotonic and intuitive: a higher setting always keeps the
+        # battery fuller and pulls more charging into TODAY (the deficit /
+        # midnight-constraint logic charges to reach the reserve).
+        #
+        # The previous code returned max(fixed_floor, min_kwh) and ignored
+        # dynamic_reserve entirely, so a fixed reserve below the dynamic value
+        # counter-intuitively LOWERED the target and charged the battery LESS
+        # full than reserve_target_pct=0 (pure dynamic) would have.
+        return min(config.battery_capacity_kwh, max(fixed_floor, dynamic_reserve))
 
-    # Self-consumption priority: hold extra reserve to favour PV self-use
-    # over grid exports.  Adds a 25% buffer on top of the overnight reserve.
-    multiplier = 1.25 if config.optimization_priority == "self_consumption" else 1.0
-    return min(config.battery_capacity_kwh, min_kwh + reserve_kwh * multiplier)
+    return min(config.battery_capacity_kwh, dynamic_reserve)
 
 
 def calculate_net_pv_surplus(
@@ -1065,15 +1079,17 @@ def select_unified_charge_slots(
             current_kwh + net_pv + today_charge - drain_to_midnight
         ))
 
-        # Mirror _compute_reserve_target: fixed floor and self_consumption
-        # boost apply to tomorrow's reserve just like today's.
+        # Mirror _compute_reserve_target: the dynamic overnight reserve (with
+        # the self_consumption boost) is the baseline; a fixed reserve can
+        # only RAISE it, never lower it below the survival need.
+        multiplier = 1.25 if optimization_priority == "self_consumption" else 1.0
+        dynamic_tmr = min_kwh + tomorrow_reserve * multiplier
         if reserve_target_pct > 0:
             fixed_floor = (reserve_target_pct / 100.0) * battery_capacity
-            tomorrow_reserve_target = min(battery_capacity, max(fixed_floor, min_kwh))
-        else:
-            multiplier = 1.25 if optimization_priority == "self_consumption" else 1.0
             tomorrow_reserve_target = min(
-                battery_capacity, min_kwh + tomorrow_reserve * multiplier)
+                battery_capacity, max(fixed_floor, dynamic_tmr))
+        else:
+            tomorrow_reserve_target = min(battery_capacity, dynamic_tmr)
         daytime_gap = max(0.0, consumption_est - tomorrow_pv)
         # PV surplus beyond consumption will charge the battery during the day,
         # reducing the need for grid charging overnight.

--- a/custom_components/ha_felicity/frontend/ha_felicity_ems.js
+++ b/custom_components/ha_felicity/frontend/ha_felicity_ems.js
@@ -225,14 +225,17 @@ class FelicityEMSCard extends LitElement {
     const inverterMaxKw = sim.inverter_max_power_kw || 10;
     const yesterdayDeficit = this._getAttr("schedule_status", "yesterday_deficit_kwh") || 0;
 
-    // Mirrors ems._compute_reserve_target: fixed floor if reserveTargetPct > 0,
-    // otherwise dynamic (dischargeMin floor + overnight reserve).
+    // Mirrors ems._compute_reserve_target: a fixed reserve (reserveTargetPct
+    // > 0) can only RAISE the target above the dynamic overnight-survival
+    // reserve, never lower it below it.  (The 1.25× self_consumption boost on
+    // the dynamic value is a backend-only refinement, not mirrored here.)
     const computeReserveTarget = (minKwh, reserveKwh) => {
+      const dynamic = minKwh + reserveKwh;
       if (reserveTargetPct > 0) {
         const fixedFloor = (reserveTargetPct / 100) * batteryCapacity;
-        return Math.min(batteryCapacity, Math.max(fixedFloor, minKwh));
+        return Math.min(batteryCapacity, Math.max(fixedFloor, dynamic));
       }
-      return Math.min(batteryCapacity, minKwh + reserveKwh);
+      return Math.min(batteryCapacity, dynamic);
     };
 
     const numSlots = slotData.length;
@@ -1216,14 +1219,17 @@ class FelicityEMSCard extends LitElement {
     const consumption = sim.consumption_est_kwh || 10;
     const inverterMaxKw = sim.inverter_max_power_kw || 10;
 
-    // Mirrors ems._compute_reserve_target: fixed floor if reserveTargetPct > 0,
-    // otherwise dynamic (dischargeMin floor + overnight reserve).
+    // Mirrors ems._compute_reserve_target: a fixed reserve (reserveTargetPct
+    // > 0) can only RAISE the target above the dynamic overnight-survival
+    // reserve, never lower it below it.  (The 1.25× self_consumption boost on
+    // the dynamic value is a backend-only refinement, not mirrored here.)
     const computeReserveTarget = (minKwhArg, reserveKwhArg) => {
+      const dynamic = minKwhArg + reserveKwhArg;
       if (reserveTargetPct > 0) {
         const fixedFloor = (reserveTargetPct / 100) * batteryCapacity;
-        return Math.min(batteryCapacity, Math.max(fixedFloor, minKwhArg));
+        return Math.min(batteryCapacity, Math.max(fixedFloor, dynamic));
       }
-      return Math.min(batteryCapacity, minKwhArg + reserveKwhArg);
+      return Math.min(batteryCapacity, dynamic);
     };
 
     const numSlots = slotData.length;

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -2032,15 +2032,49 @@ class TestComputeReserveTarget:
         target = _compute_reserve_target(config, reserve_kwh=10.0)
         assert target == 48.0  # 80% of 60
 
-    def test_fixed_floor_below_discharge_min(self):
-        """reserve_target_pct below discharge_min uses discharge_min instead."""
+    def test_fixed_floor_below_dynamic_raises_to_dynamic(self):
+        """A fixed reserve below the dynamic survival need is raised to it.
+
+        reserve_target_pct is a monotonic floor: it can only RAISE the target,
+        never lower it below the overnight-survival reserve (which itself is
+        >= the hardware discharge minimum).  Here 10% (6 kWh) is below both
+        discharge_min (40% = 24 kWh) and the dynamic reserve (24 + 5 = 29),
+        so the dynamic reserve wins.
+        """
         config = default_config(
             battery_capacity_kwh=60.0,
             battery_discharge_min_pct=40.0,
-            reserve_target_pct=10.0,  # 10% = 6 kWh, but min is 40% = 24 kWh
+            reserve_target_pct=10.0,  # 10% = 6 kWh — below survival need
         )
         target = _compute_reserve_target(config, reserve_kwh=5.0)
-        assert target == 24.0  # discharge_min wins
+        assert target == 29.0  # dynamic survival reserve wins (24 + 5)
+
+    def test_fixed_reserve_never_lowers_below_dynamic(self):
+        """Setting a reserve must never charge the battery LESS full.
+
+        Regression test for the counterintuitive bug: a fixed reserve below
+        the dynamic+boost value used to be returned verbatim, lowering the
+        target below what reserve_target_pct=0 would produce.  Now the fixed
+        value can only raise the target.
+        """
+        # self_consumption dynamic reserve = 12 + 16*1.25 = 32 kWh.
+        base = dict(
+            battery_capacity_kwh=60.0,
+            battery_discharge_min_pct=20.0,
+            optimization_priority="self_consumption",
+        )
+        dynamic = _compute_reserve_target(
+            default_config(reserve_target_pct=0.0, **base), reserve_kwh=16.0)
+        # A user setting 35% (= 21 kWh) — BELOW the 32 kWh dynamic reserve.
+        fixed_low = _compute_reserve_target(
+            default_config(reserve_target_pct=35.0, **base), reserve_kwh=16.0)
+        assert fixed_low >= dynamic, (
+            f"fixed reserve {fixed_low} lowered the target below dynamic {dynamic}"
+        )
+        # A user setting 80% (= 48 kWh) — ABOVE the dynamic reserve — raises it.
+        fixed_high = _compute_reserve_target(
+            default_config(reserve_target_pct=80.0, **base), reserve_kwh=16.0)
+        assert fixed_high == 48.0
 
     def test_fixed_floor_capped_at_capacity(self):
         """reserve_target_pct=100 returns battery capacity."""


### PR DESCRIPTION
…er lowers

User-reported bug: setting a fixed reserve_target_pct could charge the battery LESS full than reserve_target_pct=0 (dynamic). The old formula returned max(fixed_floor, discharge_min) and ignored the dynamic overnight-survival reserve and the self_consumption 1.25x boost entirely. So a fixed reserve below the dynamic value lowered the target -> lower midnight constraint -> less today-charging -> defers everything to tomorrow's cheaper slots. "I want more reserve" produced "charge less full" — exactly backwards.

Fix: reserve_target = max(fixed_floor, dynamic_reserve). The setting now behaves as a monotonic floor — it can only RAISE the target above the overnight-survival need, never lower it. Higher value keeps the battery fuller at all times and pulls more charging into today (the deficit / MILP midnight-constraint logic charges to reach the reserve).

Single source of truth: fix lives in ems._compute_reserve_target, so greedy (_schedule_from_grid/_schedule_both) and MILP (precomputed reserve_target) both inherit it. Mirrored in select_unified_charge_slots (tomorrow-side reserve) and both JS-card preview computeReserveTarget helpers so the slider preview stays consistent with the backend.

Tests: updated test_fixed_floor_below_discharge_min -> now asserts the dynamic reserve wins; added test_fixed_reserve_never_lowers_below_dynamic regression test. 229 passing.

Docs: CLAUDE.md Reserve Target section rewritten with the monotonic-floor semantics, the bug history, and updated parameter tables.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF