### PR TITLE
Fix F821: import INVERTER_MODEL_TREX_FIVE used in Economic-mode self-…

### DIFF
--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -14,6 +14,7 @@ from pymodbus.exceptions import ModbusException, ConnectionException
 from .const import (
     DOMAIN, INVERTER_MODEL_TREX_TEN, CONF_INVERTER_MODEL,
     DEFAULT_INVERTER_MODEL, INVERTER_MAX_POWER_KW,
+    INVERTER_MODEL_TREX_FIVE,
     INVERTER_MODEL_TREX_TWENTY_FIVE, INVERTER_MODEL_TREX_FIFTY,
 )
 from .type_specific import TypeSpecificHandler


### PR DESCRIPTION
…heal

The self-heal's TREX-5/10 branch referenced INVERTER_MODEL_TREX_FIVE but only TREX_TEN/TWENTY_FIVE/FIFTY were imported.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF