### PR TITLE
Fix override SOC trajectory "forgetting PV" when forecast has no hour…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -724,6 +724,19 @@ their `_simOverrides` entry after 2 s (like `_commitPower` does for
 `powerKw`) — previously they stuck forever, keeping `hasSliderOverrides`
 true and pinning the card to the client trajectory permanently.
 
+**Override recompute must mirror calculate_schedule's PV synthesis**: when
+the forecast has no hourly breakdown, `calculate_schedule` internally
+rebuilds `state` with `_synthesize_pv_hourly(daily_total)` so the trajectory
+accounts for solar — but that rebuilt state is NOT returned.  The
+coordinator's override recompute therefore re-applies the same synthesis
+(`dataclasses.replace(state, pv_hourly_kwh=_synthesize_pv_hourly(...))`)
+before calling `_compute_scheduled_soc_trajectory`.  Without it the override
+trajectory "forgets PV" entirely and draws a far-too-low curve (real
+customer report: 12 charge slots + big PV remaining, SOC line barely rose).
+This is a documented coupling/duplication smell — the clean long-term fix is
+to pass overrides INTO `calculate_schedule` so ems.py owns the whole merge +
+trajectory, but that's a larger refactor.
+
 ### Past Slot History
 Fetches `energy_state` history from HA API (throttled 60s), shows what actually happened vs what was planned.
 

--- a/custom_components/ha_felicity/coordinator.py
+++ b/custom_components/ha_felicity/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for Felicity with proper async handling."""
 
 import asyncio
+import dataclasses
 import json
 import logging
 import math
@@ -987,10 +988,26 @@ class HA_FelicityCoordinator(DataUpdateCoordinator):
             )
             current_slot_r = min(current_slot_r, num_slots_r - 1)
             current_kwh_r = (battery_soc / 100.0) * effective_capacity
+            # Mirror calculate_schedule's PV synthesis: when the forecast has
+            # no hourly breakdown, ems.calculate_schedule internally rebuilds
+            # the state with a synthesized hourly PV curve (from the daily
+            # total) so the trajectory accounts for solar.  That rebuilt state
+            # is NOT returned, so this recompute must apply the same synthesis
+            # — otherwise the override trajectory "forgets PV" and draws a
+            # far-too-low curve (real customer report: 12 charge slots + big PV
+            # remaining, yet the SOC line barely rose).
+            traj_state = state
+            if not state.pv_hourly_kwh:
+                forecast_total = self.pv_forecast_today or pv_fallback
+                if forecast_total and forecast_total > 0:
+                    traj_state = dataclasses.replace(
+                        state,
+                        pv_hourly_kwh=ems_module._synthesize_pv_hourly(forecast_total),
+                    )
             self._backend_soc_trajectory = ems_module._compute_scheduled_soc_trajectory(
                 self.slot_prices_today, num_slots_r, minutes_per_slot_r,
                 current_kwh_r, current_slot_r,
-                self.scheduled_slots, config, state,
+                self.scheduled_slots, config, traj_state,
             )
         else:
             self._backend_soc_trajectory = result.soc_trajectory


### PR DESCRIPTION
…ly data

When the PV forecast provides only a daily total (no hourly breakdown), calculate_schedule internally rebuilds the state with a synthesized hourly PV curve (_synthesize_pv_hourly) so the default trajectory accounts for solar. That rebuilt state is NOT returned, so the coordinator's override-trajectory recompute used the raw state with EMPTY pv_hourly — producing a curve with NO PV at all. Hence "12 charge slots + big PV remaining, yet the SOC line barely rose": the override recompute forgot the sun.

The recompute now re-applies the same synthesis (dataclasses.replace on the state with _synthesize_pv_hourly from pv_forecast_today or the 7-day fallback) before computing the trajectory. Reproduced: with empty pv_hourly the curve peaks ~93% and dips early; with synthesis it reaches 100% — matching the default (no-override) path.

Documented as a coupling smell; the clean fix is to pass overrides into calculate_schedule so ems.py owns the merge + trajectory.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF