### PR TITLE
Simulator: visualize PV production + add PV-variant scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+tools/sim_output/

--- a/tools/README.md
+++ b/tools/README.md
@@ -101,8 +101,18 @@ specific knobs and asserts the intended outcome.  The current set covers:
 | `tomorrow_pv_daily_only` | daily-only forecast, two-day | tomorrow's PV is synthesised (not zero) |
 | `longevity_cycle_cost` | both, longevity | wear floor suppresses marginal trades |
 | `arbitrage_delta_gate` | both, arbitrage_price_delta | no sells below the required spread |
+| `pv_sunny_fills_battery_no_grid` | from_grid, big PV | solar fills the battery → no grid charge |
+| `pv_cloudy_low_confidence_charges_more` | PV forecast vs actual | low PV confidence → charges more |
+| `pv_daily_total_only_today` | daily-only forecast | hourly PV is **synthesized** (SOC still rises) |
+| `pv_no_sun_winter_relies_on_grid` | zero PV | charges the cheapest grid slots |
+| `pv_surplus_sold_to_grid` | to_grid, big PV | sells the solar surplus at peak |
 | `manual_from_grid_no_charge_above_threshold` | **price_mode=manual**, from_grid | **customer case**: never charge above the threshold |
 | `manual_both_sell_above_charge_below` | **price_mode=manual**, both | charge below / sell above the threshold, no overlap |
+
+Every chart overlays the **PV production** as a translucent yellow "solar hump"
+(kWh/h, on its own right axis) — synthesized from the daily total when the
+forecast has no hourly breakdown — so you can see the SOC line rise as the sun
+produces and confirm the algorithm is using the solar.
 
 ### Manual price mode
 

--- a/tools/ems_simulator.py
+++ b/tools/ems_simulator.py
@@ -185,10 +185,16 @@ def report_one(scenario: dict, results: dict) -> bool:
     print(f"  {scenario.get('desc', '')}")
     cfg = scenario["config"]
     st = scenario["state"]
+    prices0 = st.get("slot_prices_today") or []
+    n0 = len(prices0)
+    pv_disp = effective_pv_per_slot(st, n0)
+    pv_total = round(sum(pv_disp), 1)
+    pv_src = "hourly" if st.get("pv_hourly_kwh") else ("synthesized" if (st.get("pv_forecast_today") or 0) > 0 else "none")
     print(f"  grid_mode={cfg.get('grid_mode')} priority={cfg.get('optimization_priority','cost')} "
           f"cap={cfg.get('battery_capacity_kwh')}kWh SOC={st.get('battery_soc_pct')}% "
           f"time={st.get('current_hour',0):02d}:{st.get('current_minute',0):02d} "
-          f"consumption={cfg.get('consumption_est_kwh')}kWh/d")
+          f"consumption={cfg.get('consumption_est_kwh')}kWh/d "
+          f"PV_today={pv_total}kWh({pv_src})")
     prices = st.get("slot_prices_today") or []
     for engine, r in results.items():
         print(f"  [{engine:>6}] charge={_fmt_slots(r['charge_slots'], prices)}")
@@ -210,6 +216,31 @@ def report_one(scenario: dict, results: dict) -> bool:
             print(f"  >>> [{engine:>6}] {tag}: {msg}")
             ok = ok and passed
     return ok
+
+
+def effective_pv_per_slot(state_kwargs: dict, n: int, tomorrow: bool = False):
+    """The per-slot PV (kWh) the algorithm effectively sees, for plotting.
+
+    Uses the supplied hourly PV when present, otherwise SYNTHESIZES it from the
+    daily forecast total with the SAME helper the algorithm uses
+    (ems._synthesize_pv_hourly) — so 'daily-only forecast' scenarios still show
+    a realistic solar hump instead of a flat zero.
+    """
+    if n == 0:
+        return [0.0] * 0
+    key = "pv_hourly_kwh_tomorrow" if tomorrow else "pv_hourly_kwh"
+    hourly = state_kwargs.get(key)
+    if not hourly:
+        total_key = "pv_forecast_tomorrow" if tomorrow else "pv_forecast_today"
+        total = state_kwargs.get(total_key) or 0.0
+        hourly = ems._synthesize_pv_hourly(total) if total > 0 else {}
+    mps = (24 * 60) / n
+    out = []
+    for i in range(n):
+        hour = int((i * mps) / 60) % 24
+        val = hourly.get(hour, hourly.get(str(hour), 0.0)) if hourly else 0.0
+        out.append(val * (mps / 60.0))
+    return out
 
 
 def plot_scenario(scenario: dict, results: dict, outdir: str):
@@ -243,6 +274,21 @@ def plot_scenario(scenario: dict, results: dict, outdir: str):
                        label=f"threshold {r['threshold']:.3f}")
             ax.legend(loc="upper left", fontsize=7)
         ax.set_title(f"{scenario['name']} — {engine} (charge=green sell=orange)  reason: {r['reason']}", fontsize=8)
+
+        # PV production (kWh/h) as a translucent yellow solar hump on its own
+        # right-offset axis — synthesized from the daily total when the forecast
+        # has no hourly breakdown (so it's never invisibly flat).
+        pv = effective_pv_per_slot(scenario["state"], n)
+        if any(v > 0 for v in pv):
+            axpv = ax.twinx()
+            axpv.spines["right"].set_position(("outward", 38))
+            axpv.fill_between([i + 0.5 for i in range(n)], pv, color="#ffd400",
+                              alpha=0.30, step="mid", label="PV kWh/h")
+            axpv.set_ylim(0, max(pv) * 1.4 if max(pv) > 0 else 1)
+            axpv.set_ylabel("PV kWh/h", color="#b59500")
+            axpv.tick_params(axis="y", labelcolor="#b59500")
+            axpv.legend(loc="upper center", fontsize=7)
+
         # SOC trajectory on a twin axis
         traj = r["trajectory"]
         if traj:

--- a/tools/scenarios.py
+++ b/tools/scenarios.py
@@ -255,6 +255,103 @@ SCENARIOS = [
         ),
     },
 
+    # ── PV variants ─────────────────────────────────────────────────────────
+    {
+        "name": "pv_sunny_fills_battery_no_grid",
+        "desc": "from_grid, morning, big PV remaining: solar will fill the battery → "
+                "no grid charging needed (solar protection).",
+        "config": dict(grid_mode="from_grid", optimization_priority="self_consumption",
+                       battery_capacity_kwh=10.0, battery_discharge_min_pct=20,
+                       battery_charge_max_pct=100, efficiency=0.90,
+                       safe_power_kw=5.0, inverter_max_power_kw=10.0,
+                       consumption_est_kwh=8.0),
+        "state": dict(battery_soc_pct=55.0, slot_prices_today=cheap_night_expensive_day(),
+                      pv_hourly_kwh=pv_bell(30.0),           # big sunny day
+                      pv_actual_today_kwh=2.0, pv_forecast_today=30.0,
+                      pv_forecast_remaining=28.0, current_hour=8, current_minute=0),
+        "expect": lambda r, s: (
+            len(r["charge_slots"]) == 0,
+            f"solar fills battery → no grid charge (got {len(r['charge_slots'])}; "
+            f"projected_low={r['projected_low_pct']}%)",
+        ),
+    },
+
+    {
+        "name": "pv_cloudy_low_confidence_charges_more",
+        "desc": "Forecast said sunny but ACTUAL is low → PV confidence drops → must grid-charge "
+                "more than the sunny case to stay safe.",
+        "config": dict(grid_mode="from_grid", optimization_priority="self_consumption",
+                       battery_capacity_kwh=10.0, battery_discharge_min_pct=20,
+                       battery_charge_max_pct=100, efficiency=0.90,
+                       safe_power_kw=5.0, inverter_max_power_kw=10.0,
+                       consumption_est_kwh=12.0),
+        "state": dict(battery_soc_pct=35.0, slot_prices_today=cheap_night_expensive_day(),
+                      pv_hourly_kwh=pv_bell(30.0),           # forecast: sunny
+                      pv_actual_today_kwh=0.5,               # actual: barely producing
+                      pv_forecast_today=30.0, pv_forecast_remaining=20.0,
+                      current_hour=12, current_minute=0),
+        "expect": lambda r, s: (
+            len(r["charge_slots"]) > 0,
+            f"low PV confidence → charges to cover deficit (got {len(r['charge_slots'])})",
+        ),
+    },
+
+    {
+        "name": "pv_daily_total_only_today",
+        "desc": "Forecast gives only a DAILY total today (no hourly) → algorithm must SYNTHESIZE "
+                "the hourly curve so the SOC accounts for solar (chart shows a yellow hump).",
+        "config": dict(grid_mode="from_grid", optimization_priority="self_consumption",
+                       battery_capacity_kwh=10.0, battery_discharge_min_pct=20,
+                       battery_charge_max_pct=100, efficiency=0.90,
+                       safe_power_kw=5.0, inverter_max_power_kw=10.0,
+                       consumption_est_kwh=8.0),
+        "state": dict(battery_soc_pct=50.0, slot_prices_today=cheap_night_expensive_day(),
+                      pv_hourly_kwh={},                      # NO hourly breakdown
+                      pv_actual_today_kwh=1.0, pv_forecast_today=25.0,
+                      pv_forecast_remaining=22.0, current_hour=8, current_minute=0),
+        "expect": lambda r, s: (
+            (r["projected_low_pct"] or 0) >= 40.0,
+            f"synthesized PV keeps SOC up (projected_low={r['projected_low_pct']}%, "
+            f"expected >=40 since 25 kWh PV on a 10 kWh battery)",
+        ),
+    },
+
+    {
+        "name": "pv_no_sun_winter_relies_on_grid",
+        "desc": "Zero PV (winter), low SOC: must charge from the cheapest grid slots.",
+        "config": dict(grid_mode="from_grid", optimization_priority="self_consumption",
+                       battery_capacity_kwh=10.0, battery_discharge_min_pct=20,
+                       battery_charge_max_pct=100, efficiency=0.90,
+                       safe_power_kw=5.0, inverter_max_power_kw=10.0,
+                       consumption_est_kwh=12.0),
+        "state": dict(battery_soc_pct=30.0, slot_prices_today=cheap_night_expensive_day(),
+                      pv_hourly_kwh={}, pv_actual_today_kwh=0.0,
+                      pv_forecast_today=0.0, pv_forecast_remaining=0.0,
+                      current_hour=3, current_minute=0),
+        "expect": lambda r, s: (
+            len(r["charge_slots"]) > 0 and all(p <= 0.16 for p in r["charge_prices"]),
+            f"no PV → charges cheap grid slots (got {r['charge_prices']})",
+        ),
+    },
+
+    {
+        "name": "pv_surplus_sold_to_grid",
+        "desc": "to_grid, big PV fills the battery past reserve → sell the solar surplus at peak.",
+        "config": dict(grid_mode="to_grid", optimization_priority="cost",
+                       battery_capacity_kwh=15.0, battery_discharge_min_pct=20,
+                       battery_charge_max_pct=100, efficiency=0.90,
+                       safe_power_kw=8.0, inverter_max_power_kw=12.0,
+                       consumption_est_kwh=6.0),
+        "state": dict(battery_soc_pct=70.0, slot_prices_today=cheap_day_expensive_evening(),
+                      pv_hourly_kwh=pv_bell(30.0), pv_actual_today_kwh=1.0,
+                      pv_forecast_today=30.0, pv_forecast_remaining=28.0,
+                      current_hour=7, current_minute=0),
+        "expect": lambda r, s: (
+            len(r["sell_slots"]) > 0 and all(p >= 0.30 for p in r["sell_prices"]),
+            f"sells solar surplus at peak prices (got {r['sell_prices']})",
+        ),
+    },
+
     {
         "name": "manual_from_grid_no_charge_above_threshold",
         "desc": "CUSTOMER CASE: price_mode=manual, from_grid. Must charge ONLY below the "


### PR DESCRIPTION
The charts didn't show PV, which is the single most important input for a solar-first EMS. Now every chart overlays the hourly PV production as a translucent yellow "solar hump" (kWh/h on its own right axis), synthesized from the daily total when the forecast has no hourly breakdown — so you can SEE the SOC line rise as the sun produces and confirm the algorithm uses it. The text report also prints PV_today (with hourly/synthesized/none source).

Added 5 PV-variant scenarios with assertions:
  - pv_sunny_fills_battery_no_grid   (solar fills battery -> no grid charge)
  - pv_cloudy_low_confidence_charges_more (forecast sunny, actual low -> charges)
  - pv_daily_total_only_today        (daily-only forecast -> synthesized hourly)
  - pv_no_sun_winter_relies_on_grid  (zero PV -> cheapest grid slots)
  - pv_surplus_sold_to_grid          (to_grid big PV -> sell surplus at peak)

Verified the chart renders correctly (PV hump + rising SOC, both engines). Generated charts gitignored. 240 tests + 16 simulator scenarios green.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF