### PR TITLE
milp: charge the earlier of equal-price slots (robustness buffer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1258,6 +1258,14 @@ Forward-simulates SOC through every slot.  Drops violations:
   because its reserve is the 1.25× boosted value.  The today extraction target
   is also capped at the LP's allocated charge energy (not just headroom) so the
   discrete schedule reflects the cost-correct intent.
+- **Earliness tie-break**: a tiny per-slot deferral penalty on charging
+  (`(avg+0.01)·1e-4 · k · c[k]`, far below any real price granularity) makes
+  the solver charge the EARLIER of two equal-price slots.  Without it the LP is
+  indifferent between same-price slots and tends to charge at the LAST cheap
+  slot before a sell — leaving the battery low for hours and exposed to a
+  sudden unexpected load.  Charging earlier gives the same-cost plan a safety
+  buffer (a real customer preference: "don't hold off to the last minute").
+  Never flips a genuine price difference (only breaks ties).
 - **Price gates**: `arbitrage_price_delta` → charge/discharge UB = 0 for
   slots outside spread.  `block_export_on_negative_price` → discharge UB = 0.
 - **Post-solve (cost-ranked discrete extraction)**: the continuous LP is

--- a/custom_components/ha_felicity/milp.py
+++ b/custom_components/ha_felicity/milp.py
@@ -315,10 +315,15 @@ def _solve(
     reward_soc = pulp.LpVariable("reward_soc", lowBound=0, upBound=reserve_clamped)
     prob += reward_soc <= soc[K - 1]
 
-    # Objective: minimise net grid spend + wear − value of leftover energy
-    # (capped at the reserve) + reserve-shortfall penalty (drives charging
-    # toward the reserve when physically feasible; absorbs the unreachable
-    # remainder instead of making the model infeasible).
+    # Earliness preference: when several slots share the SAME price, charge the
+    # EARLIER one.  The cost objective is indifferent between equal-price slots,
+    # so the solver would otherwise pick arbitrarily (often the latest, right
+    # before a sell) — leaving the battery low for hours and exposed to a sudden
+    # unexpected load (less buffer, less ability to anticipate).  A tiny per-
+    # slot deferral penalty on charging (scaled far below any real price
+    # granularity, so it NEVER flips a genuine price difference — only breaks
+    # ties) nudges charging earlier, giving the same-cost plan a safety buffer.
+    early = (avg_price + 0.01) * 1e-4
     prob += (
         pulp.lpSum(horizon[k]["price"] * c[k] for k in range(K))           # buy cost
         - pulp.lpSum(horizon[k]["price"] * eff * d[k] for k in range(K))   # sell revenue
@@ -326,6 +331,7 @@ def _solve(
         - terminal_value * reward_soc                                      # leftover value (≤ reserve)
         + pulp.lpSum(reserve_penalty * s for s in reserve_shortfalls)      # soft reserve
         + pulp.lpSum(reserve_penalty * imp[k] for k in range(K))           # feasibility slack
+        + pulp.lpSum(early * k * c[k] for k in range(K))                   # charge earlier (tie-break)
     )
 
     solver = pulp.PULP_CBC_CMD(msg=0, timeLimit=_SOLVE_TIME_LIMIT)


### PR DESCRIPTION
The cost objective is indifferent between slots that share the same price, so the solver picked arbitrarily — often the LAST cheap slot right before a sell (trader_arbitrage charged at slots 14,15 just before the evening peak).  That leaves the battery low for hours and exposed to a sudden unexpected load, with less ability to anticipate it.  A customer flagged this: greedy charges sooner (more buffer), MILP held off to the last minute.

Add a tiny per-slot deferral penalty on charging — (avg+0.01)*1e-4 * k * c[k], scaled far below any real price granularity so it NEVER flips a genuine price difference, only breaks ties.  MILP now charges the earliest equal-price slots: trader_arbitrage 14,15 -> 9,10; cons_heavy 4,5 -> 2,3; self_suff 15,16 -> 11,12 — all at the SAME prices (no cost change), just earlier for the buffer.  to_grid still sells the peak, duck still the midday trough, negatives still all grabbed.  245 tests pass; all scenarios green.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF