### PR TITLE
fix: options flow no longer wipes untouched entity assignments on save

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1853,9 +1853,19 @@ wiring) found and fixed:
   slider state parsing.
 
 **Config wiring**
-- Options-flow entity pickers use `description={"suggested_value": ...}`
-  with explicit absent→clear handling — assigned entities can now be
-  unassigned (was a one-way ratchet via `default=`).
+- Options-flow entity pickers use `description={"suggested_value": ...}` and
+  are merged onto the existing options with `my_options.update(user_input)` —
+  **absence is NOT treated as a clear** (fixed).  The old "absent→clear" loop
+  wiped every entity assignment the user didn't re-touch on ANY unrelated
+  Settings save, because the HA frontend can omit an untouched suggested-value
+  optional selector from the submitted form.  Real customer symptom: an update
+  during which Settings was opened+saved silently cleared
+  `flexible_load_1_current_entity` → `is_ev_charger` went false → the EV Boost
+  button disappeared (and Nordpool/forecast assignments could vanish the same
+  way).  An EXPLICIT clear still works (the frontend submits a cleared picker
+  as `None`/`""`, which `.update()` applies); an untouched one is preserved.
+  `__init__.async_setup_entry` also logs the load-1 EV config at startup so
+  "button disappeared" reports can be diagnosed from the log directly.
 - `_get_default_options` includes the negative-price + rule1 keys.
 - `select.py current_option` normalizes legacy bool values.
 - `number.py` nested f-string quote fixed (Python <3.12 tooling).

--- a/custom_components/ha_felicity/__init__.py
+++ b/custom_components/ha_felicity/__init__.py
@@ -248,6 +248,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if updated_options != options:
         hass.config_entries.async_update_entry(entry, options=updated_options)
 
+    # Diagnostic: surface whether load 1 is recognised as an EV charger (needs
+    # BOTH a current entity and current steps).  If a user reports "the EV Boost
+    # button disappeared", this line in the log tells us immediately whether the
+    # persisted config still has those two fields after an update.
+    _ev_current_entity = updated_options.get("flexible_load_1_current_entity", "")
+    _ev_current_steps = updated_options.get("flexible_load_1_current_steps", "")
+    _LOGGER.info(
+        "Flex load 1 EV config: switch=%s current_entity=%s current_steps=%r "
+        "→ EV charger %s (EV Boost button %s)",
+        updated_options.get("flexible_load_1_switch_entity", "") or "(unset)",
+        _ev_current_entity or "(unset)",
+        _ev_current_steps or "",
+        "RECOGNISED" if (_ev_current_entity and _ev_current_steps) else "NOT recognised",
+        "shown" if (_ev_current_entity and _ev_current_steps) else "hidden",
+    )
+
     nordpool_entity = updated_options.get("nordpool_entity")
     nordpool_override = updated_options.get("nordpool_override")
     forecast_entity = updated_options.get("forecast_entity")

--- a/custom_components/ha_felicity/config_flow.py
+++ b/custom_components/ha_felicity/config_flow.py
@@ -412,9 +412,8 @@ class FelicityOptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize options flow."""
         # self.config_entry = config_entry  # read only!! HA config fails if this is not removed!
 
-    # Optional entity pickers.  The HA frontend omits a cleared optional
-    # field from the submitted form, so absence must be treated as an
-    # explicit clear — otherwise an assigned entity can never be removed.
+    # Optional entity pickers.  (Kept for reference; NO LONGER force-cleared on
+    # absence — see async_step_init.)
     _OPTIONAL_ENTITY_KEYS = (
         "nordpool_entity",
         "nordpool_override",
@@ -432,10 +431,20 @@ class FelicityOptionsFlowHandler(config_entries.OptionsFlow):
         try:
             my_options = dict(self.config_entry.options)
             if user_input is not None:
+                # Merge the submitted form onto the EXISTING options.  We do NOT
+                # force-clear optional entity pickers that are absent from
+                # user_input: the HA frontend can omit an UNTOUCHED
+                # suggested-value optional entity selector, so force-clearing on
+                # absence wiped every entity assignment the user didn't re-touch
+                # on any unrelated Save.  Real customer symptom: opening Settings
+                # to change one thing silently cleared
+                # `flexible_load_1_current_entity`, which flipped the EV charger
+                # off (is_ev_charger=False) and made the EV Boost button vanish;
+                # likewise it could drop the Nordpool / forecast entities.  An
+                # EXPLICIT clear still works — the frontend submits a cleared
+                # picker as None/"" (present in user_input), so `.update()`
+                # applies it — but an untouched assignment is now preserved.
                 my_options.update(user_input)
-                for key in self._OPTIONAL_ENTITY_KEYS:
-                    if key not in user_input:
-                        my_options[key] = ""
                 return self.async_create_entry(title="", data=my_options)
             # Get current values from options (with defaults)
             current_register_set = my_options.get(CONF_REGISTER_SET, DEFAULT_REGISTER_SET)


### PR DESCRIPTION
Customer: "I only ever UPDATE the integration, and the update made settings disappear — the EV Boost button is gone."  The version-update path itself is clean (async_setup_entry only fills MISSING defaults, never deletes), but the options flow had a force-clear loop:

    my_options.update(user_input)
    for key in _OPTIONAL_ENTITY_KEYS:
        if key not in user_input:
            my_options[key] = ""     # <-- wipes untouched pickers

The HA frontend can omit an UNTOUCHED suggested-value optional entity selector from the submitted form, so opening Settings and saving ANYTHING cleared every entity assignment the user hadn't re-touched.  Clearing flexible_load_1_current_entity flips is_ev_charger to false, which hides the EV Boost button and disables EV current stepping; the Nordpool / forecast assignments could vanish the same way.  This is almost certainly what the user experienced "on update" (Settings opened + saved as part of updating).

Fix: drop the force-clear loop.  my_options.update(user_input) already applies an EXPLICIT clear (a cleared picker is submitted as None/""), so an assignment can still be removed, while an untouched one is now preserved.

Also log the load-1 EV config (switch / current_entity / current_steps → recognised?) once at async_setup_entry, so any future "button disappeared" report is diagnosable straight from the log.  248 tests pass.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF