### PR TITLE
sim: two-day horizon by default so every scenario chart shows today+t…

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -143,24 +143,30 @@ there is a flat placeholder, since the simulator has no recorder history).
 
 The scheduler's real horizon is **today's remaining slots plus all of tomorrow**
 (the MILP optimises the two days jointly; greedy reconstructs tomorrow via
-`_compute_tomorrow_schedule`).  The chart matches that:
+`_compute_tomorrow_schedule`).  **The chart matches that by default:** every
+optimizer scenario renders the full **48 h** window — today on the left,
+**tomorrow** on the right, a grey **midnight divider** between them, and
+`TODAY` / `TOMORROW` labels.  Prices, the PV hump (tomorrow's synthesized from
+`pv_forecast_tomorrow` when no hourly breakdown is given — exactly as the
+algorithm does), consumption, and the charge/sell bars are drawn for both days,
+and the blue **SOC line runs continuously from "now" through tomorrow**
+(`SOC% (now → tomorrow)`) using the algorithm's `tomorrow_soc_trajectory` — so
+you see the whole cross-day plan (e.g. a Trader selling today's peak and
+re-charging under tomorrow's sun).  The x-axis shows hour-of-day and restarts at
+0 at midnight.
 
-- A scenario with **only `slot_prices_today`** renders a single **24 h** panel
-  (now → end of today).
-- A scenario that also sets **`slot_prices_tomorrow`** renders the full **48 h**
-  window: today on the left, **tomorrow** on the right, a grey **midnight
-  divider** between them, and `TODAY` / `TOMORROW` labels.  Prices, the PV hump
-  (tomorrow's is synthesized from `pv_forecast_tomorrow` when no hourly
-  breakdown is given — exactly as the algorithm does), consumption, and the
-  charge/sell bars are drawn for both days, and the blue **SOC line runs
-  continuously from "now" through tomorrow** (`SOC% (now → tomorrow)`) using the
-  algorithm's `tomorrow_soc_trajectory` — so you can see the whole cross-day
-  plan (e.g. a Trader selling today's peak and re-charging under tomorrow's
-  sun).  The x-axis shows hour-of-day and restarts at 0 at midnight.
+Scenarios that don't define their own `slot_prices_tomorrow` get a realistic
+"tomorrow" auto-added (today's price/PV shape — a *typical similar day*), so the
+two-day view is the norm.  A scenario renders a **single 24 h** panel only when
+it opts out:
+- `"single_day": True` in the scenario dict (e.g. `pv_daily_total_only_today`,
+  which specifically tests the pre-tomorrow / no-next-day-prices path), or
+- `price_mode: "manual"` (the manual lane is a threshold rule, today-only).
 
-To exercise the two-day view in your own scenario, just add `slot_prices_tomorrow`
-(and optionally `pv_forecast_tomorrow` / `pv_hourly_kwh_tomorrow`) to its
-`state`.  See `tomorrow_pv_daily_only` and `trader_tomorrow_pv_daily_only`.
+To give a scenario a *specific* tomorrow (cross-day arbitrage, a cheaper next
+day, a bigger solar day…), set `slot_prices_tomorrow` (and optionally
+`pv_forecast_tomorrow` / `pv_hourly_kwh_tomorrow`) explicitly — see
+`tomorrow_pv_daily_only` and `trader_tomorrow_pv_daily_only`.
 
 ### Manual price mode
 

--- a/tools/scenarios.py
+++ b/tools/scenarios.py
@@ -446,6 +446,7 @@ SCENARIOS = [
 
     {
         "name": "pv_daily_total_only_today",
+        "single_day": True,  # explicitly tests the pre-tomorrow (today-only) path
         "desc": "Forecast gives only a DAILY total today (no hourly) → algorithm must SYNTHESIZE "
                 "the hourly curve so the SOC accounts for solar (chart shows a yellow hump).",
         "config": dict(grid_mode="from_grid", optimization_priority="self_consumption",
@@ -609,3 +610,31 @@ SCENARIOS = [
         ),
     },
 ]
+
+
+# ── Two-day horizon by default ───────────────────────────────────────────────
+# The scheduler's real horizon is today's remaining slots PLUS all of tomorrow,
+# so — unless a scenario opts out — give it a realistic "tomorrow" and let the
+# simulator render the full 48h view (today | tomorrow) the algorithm plans over.
+# Tomorrow mirrors today's price shape and PV (a "typical similar day"); this was
+# verified not to change any scenario's asserted outcome.  Exemptions:
+#   • `price_mode == "manual"` — the manual lane is a threshold rule, today-only.
+#   • `"single_day": True` — scenarios that specifically test the pre-tomorrow
+#     (no next-day prices) path, e.g. `pv_daily_total_only_today`.
+#   • scenarios that already define their own `slot_prices_tomorrow`.
+def _add_default_tomorrow(scn: dict) -> None:
+    st = scn["state"]
+    if (scn.get("single_day")
+            or scn["config"].get("price_mode") == "manual"
+            or st.get("slot_prices_tomorrow")):
+        return
+    st["slot_prices_tomorrow"] = list(st["slot_prices_today"])
+    if "pv_forecast_tomorrow" not in st:
+        total = st.get("pv_forecast_today")
+        if total is None and st.get("pv_hourly_kwh"):
+            total = round(sum(st["pv_hourly_kwh"].values()), 1)
+        st["pv_forecast_tomorrow"] = total or 0.0
+
+
+for _scn in SCENARIOS:
+    _add_default_tomorrow(_scn)


### PR DESCRIPTION
…omorrow

The 48h render only kicked in when a scenario set slot_prices_tomorrow, and only 2 of 23 did — so most charts (e.g. cons_heavy_flat) still showed one day, which read as "the tomorrow view doesn't work".  The scheduler's real horizon IS two days, so make that the default: scenarios without their own slot_prices_tomorrow get a realistic "tomorrow" auto-added (today's price/PV shape — a typical similar day), verified not to change any scenario's asserted outcome.  Every optimizer scenario now renders today | tomorrow with the SOC arc spanning both days.

Opt-outs render a single 24h panel: "single_day": True (e.g. pv_daily_total_only_today, which tests the pre-tomorrow path) and manual scenarios (threshold-rule, today-only).  A scenario can still define a *specific* tomorrow for cross-day cases.

All scenarios green (both engines); 250 unit tests unaffected.  README updated.


Claude-Session: https://claude.ai/code/session_01P9LAQ5ET6SU9dLWULxv2uF